### PR TITLE
perf: F1-F7 audit findings — ExportBuffer cache, argtypes fix, per-frame allocation elimination

### DIFF
--- a/src/cuda_link/cuda_ipc_exporter.py
+++ b/src/cuda_link/cuda_ipc_exporter.py
@@ -65,7 +65,6 @@ TIMESTAMP_SIZE = 8  # 8B float64 producer timestamp
 _ST_U32 = struct.Struct("<I")  # uint32 LE (write_idx, num_slots, metadata fields)
 _ST_U64 = struct.Struct("<Q")  # uint64 LE (version)
 _ST_F64 = struct.Struct("<d")  # float64 LE (timestamp)
-_ST_U8 = struct.Struct("<B")  # uint8 (shutdown_flag, magic byte)
 
 # Data type codes (must match CUDAIPCExtension and CUDAIPCImporter)
 DTYPE_FLOAT32 = 0
@@ -262,9 +261,6 @@ class CUDAIPCExporter:
             # Cache constant SharedMemory offsets so export_frame() avoids per-frame arithmetic
             self._ts_offset = SHM_HEADER_SIZE + (self.num_slots * SLOT_SIZE) + SHUTDOWN_FLAG_SIZE + METADATA_SIZE
 
-            # Bind hot-path method: fast path has zero debug-branch overhead when debug=False
-            self.export_frame = self._export_frame_debug if self.debug else self._export_frame_fast
-
             self._initialized = True
             logger.info("Initialization complete — ready for zero-copy GPU transfer")
             return True
@@ -394,52 +390,6 @@ class CUDAIPCExporter:
     def export_frame(self, gpu_ptr: int, size: int) -> bool:
         """Export one frame from GPU memory via IPC ring buffer.
 
-        Bound to ``_export_frame_fast`` or ``_export_frame_debug`` after ``initialize()``.
-        Falls back to ``_export_frame_debug`` if called before initialization.
-        """
-        return self._export_frame_debug(gpu_ptr, size)
-
-    def _export_frame_fast(self, gpu_ptr: int, size: int) -> bool:
-        """Fast export path (debug=False) — zero instrumentation overhead.
-
-        Identical logic to ``_export_frame_debug`` with all ``if self.debug`` guards removed.
-        Any change to the critical path MUST be mirrored in ``_export_frame_debug``.
-        """
-        if not self._initialized:
-            logger.warning("Not initialized — call initialize() first")
-            return False
-        try:
-            slot = self.write_idx % self.num_slots
-            if self.source_sync_event is not None:
-                self.cuda.stream_wait_event(self.ipc_stream, self.source_sync_event, 0)
-            self.cuda.memcpy_async(
-                dst=self.dev_ptrs[slot],
-                src=c_void_p(gpu_ptr),
-                count=self.data_size,
-                kind=3,  # cudaMemcpyDeviceToDevice
-                stream=self.ipc_stream,
-            )
-            if self.ipc_events[slot]:
-                self.cuda.record_event(self.ipc_events[slot], stream=self.ipc_stream)
-            # See _export_frame_debug for synchronization rationale.
-            self.cuda.stream_synchronize(self.ipc_stream)
-            self.write_idx += 1
-            _ST_F64.pack_into(self.shm_handle.buf, self._ts_offset, time.perf_counter())
-            self.shm_handle.buf[self._shutdown_offset] = 0
-            _ST_U32.pack_into(self.shm_handle.buf, 16, self.write_idx)  # publish last
-            self.frame_count += 1
-            return True
-        except (OSError, RuntimeError) as e:
-            logger.error("Export failed: %s", e)
-            traceback.print_exc()
-            return False
-
-    def _export_frame_debug(self, gpu_ptr: int, size: int) -> bool:
-        """Debug export path (debug=True) — full per-operation timing instrumentation.
-
-        This is the reference implementation. Any change to the critical path MUST
-        also be applied to ``_export_frame_fast``.
-
         Args:
             gpu_ptr: Source GPU pointer (from tensor.data_ptr()).
             size: Buffer size in bytes (from tensor.nelement() * tensor.element_size()).
@@ -450,24 +400,26 @@ class CUDAIPCExporter:
         if not self._initialized:
             logger.warning("Not initialized — call initialize() first")
             return False
-
-        if self.debug:
+        if size != self.data_size:
+            logger.error("Size mismatch: expected %d, got %d", self.data_size, size)
+            return False
+        debug = self.debug
+        if debug:
             frame_start = time.perf_counter()
-
         try:
             slot = self.write_idx % self.num_slots
 
             # GPU-side wait: ipc_stream waits for source data to be ready (non-blocking CPU).
             # Only active if record_source_sync() was called; otherwise this is a no-op.
-            if self.debug:
+            if debug:
                 _t = time.perf_counter()
             if self.source_sync_event is not None:
                 self.cuda.stream_wait_event(self.ipc_stream, self.source_sync_event, 0)
-            if self.debug:
+            if debug:
                 self.total_stream_wait_us += (time.perf_counter() - _t) * 1_000_000
 
             # Async D2D copy to this slot's persistent IPC buffer
-            if self.debug:
+            if debug:
                 memcpy_start = time.perf_counter()
             self.cuda.memcpy_async(
                 dst=self.dev_ptrs[slot],
@@ -476,15 +428,15 @@ class CUDAIPCExporter:
                 kind=3,  # cudaMemcpyDeviceToDevice
                 stream=self.ipc_stream,
             )
-            if self.debug:
+            if debug:
                 self.total_memcpy_us += (time.perf_counter() - memcpy_start) * 1_000_000
 
             # Record IPC event (stream-ordered, signals consumer that data is ready)
-            if self.debug:
+            if debug:
                 _t = time.perf_counter()
             if self.ipc_events[slot]:
                 self.cuda.record_event(self.ipc_events[slot], stream=self.ipc_stream)
-            if self.debug:
+            if debug:
                 self.total_record_event_us += (time.perf_counter() - _t) * 1_000_000
 
             # Synchronize ipc_stream to ensure the D2D copy + event record have EXECUTED on
@@ -500,18 +452,18 @@ class CUDAIPCExporter:
             # Ordering matters: the consumer reads shutdown_flag BEFORE write_idx, so
             # clearing it before incrementing write_idx ensures the consumer always sees
             # shutdown_flag=0 when it detects a new frame (atomicity improvement).
-            if self.debug:
+            if debug:
                 _t = time.perf_counter()
             self.write_idx += 1
             _ST_F64.pack_into(self.shm_handle.buf, self._ts_offset, time.perf_counter())
             self.shm_handle.buf[self._shutdown_offset] = 0
             _ST_U32.pack_into(self.shm_handle.buf, 16, self.write_idx)  # publish last
-            if self.debug:
+            if debug:
                 self.total_shm_write_us += (time.perf_counter() - _t) * 1_000_000
 
             self.frame_count += 1
 
-            if self.debug:
+            if debug:
                 frame_time = (time.perf_counter() - frame_start) * 1_000_000
                 self.total_export_us += frame_time
 

--- a/src/cuda_link/cuda_ipc_exporter.py
+++ b/src/cuda_link/cuda_ipc_exporter.py
@@ -31,8 +31,8 @@ Architecture:
 
 Performance:
     - Initialization: ~1ms (buffer alloc + handle export)
-    - Per-frame: ~10-20us at 512x512 (async D2D memcpy + event record + write_idx update)
-    - Per-frame: ~50-130us at 1080p (async D2D enqueue + IPC sync)
+    - Per-frame: ~177µs at 512x512 @ 60 FPS (includes producer-side stream_synchronize)
+    - Per-frame: ~219µs at 1080p @ 60 FPS (async D2D + stream_synchronize + protocol writes)
 
 Compatibility:
     - Protocol: v0.5.0 (byte-identical to CUDAIPCExtension/CUDAIPCImporter)
@@ -60,6 +60,12 @@ SLOT_SIZE = 128  # 64B mem_handle + 64B event_handle
 SHUTDOWN_FLAG_SIZE = 1
 METADATA_SIZE = 20  # 4B width + 4B height + 4B num_comps + 4B dtype_code + 4B buffer_size
 TIMESTAMP_SIZE = 8  # 8B float64 producer timestamp
+
+# Pre-compiled struct objects for hot-path SHM reads/writes (~50-100ns saved per call vs format-string lookup)
+_ST_U32 = struct.Struct("<I")  # uint32 LE (write_idx, num_slots, metadata fields)
+_ST_U64 = struct.Struct("<Q")  # uint64 LE (version)
+_ST_F64 = struct.Struct("<d")  # float64 LE (timestamp)
+_ST_U8 = struct.Struct("<B")  # uint8 (shutdown_flag, magic byte)
 
 # Data type codes (must match CUDAIPCExtension and CUDAIPCImporter)
 DTYPE_FLOAT32 = 0
@@ -96,7 +102,7 @@ class CUDAIPCExporter:
 
     Performance:
     - Initialization: ~1ms (buffer alloc + handle export)
-    - Per-frame overhead: ~10-20us at 512x512, ~50-130us at 1080p (async D2D enqueue + IPC sync)
+    - Per-frame overhead: ~177µs at 512x512, ~219µs at 1080p @ 60 FPS (async D2D + stream_synchronize)
     - Zero CPU memory copies (GPU-direct)
     """
 
@@ -439,16 +445,25 @@ class CUDAIPCExporter:
             if self.debug:
                 self.total_record_event_us += (time.perf_counter() - _t) * 1_000_000
 
-            # Write producer timestamp + advance write_idx + reassert shutdown_flag=0.
-            # The shutdown_flag write (1 byte) prevents a stale flag=1 from another process
-            # that shared this SharedMemory name (e.g. a TD sender that initialised first
-            # and set the flag during its cleanup) from blocking the receiver.
+            # Synchronize ipc_stream to ensure the D2D copy + event record have EXECUTED on
+            # the GPU before publishing write_idx. Without this, the consumer's query_event()
+            # may return False (event not yet signaled) even though write_idx is visible, because
+            # the GPU executes stream operations asynchronously. Blocking here guarantees the
+            # IPC event is pre-signaled when the consumer reads write_idx, so query_event()
+            # returns True on the first call (no polling delay). Cost: ~D2D GPU time per frame
+            # (~13us at 512x512, ~100us at 1080p) — acceptable for the ordering guarantee.
+            self.cuda.stream_synchronize(self.ipc_stream)
+
+            # Write timestamp, clear shutdown_flag, then publish write_idx LAST.
+            # Ordering matters: the consumer reads shutdown_flag BEFORE write_idx, so
+            # clearing it before incrementing write_idx ensures the consumer always sees
+            # shutdown_flag=0 when it detects a new frame (atomicity improvement).
             if self.debug:
                 _t = time.perf_counter()
-            struct.pack_into("<d", self.shm_handle.buf, self._ts_offset, time.perf_counter())
             self.write_idx += 1
-            struct.pack_into("<I", self.shm_handle.buf, 16, self.write_idx)
+            _ST_F64.pack_into(self.shm_handle.buf, self._ts_offset, time.perf_counter())
             self.shm_handle.buf[self._shutdown_offset] = 0
+            _ST_U32.pack_into(self.shm_handle.buf, 16, self.write_idx)  # publish last
             if self.debug:
                 self.total_shm_write_us += (time.perf_counter() - _t) * 1_000_000
 

--- a/src/cuda_link/cuda_ipc_exporter.py
+++ b/src/cuda_link/cuda_ipc_exporter.py
@@ -49,7 +49,7 @@ import traceback
 from ctypes import c_void_p
 from multiprocessing.shared_memory import SharedMemory
 
-from .cuda_ipc_wrapper import cudaIpcMemHandle_t, get_cuda_runtime  # noqa: F401
+from .cuda_ipc_wrapper import CUDAStream_t, cudaIpcMemHandle_t, get_cuda_runtime  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -389,8 +389,6 @@ class CUDAIPCExporter:
         (backward compatible). The caller is then responsible for their own sync.
         """
         if self.source_sync_event is not None and self.cuda is not None:
-            from .cuda_ipc_wrapper import CUDAStream_t
-
             self.cuda.record_event(self.source_sync_event, CUDAStream_t(producer_stream_handle))
 
     def export_frame(self, gpu_ptr: int, size: int) -> bool:

--- a/src/cuda_link/cuda_ipc_exporter.py
+++ b/src/cuda_link/cuda_ipc_exporter.py
@@ -262,6 +262,9 @@ class CUDAIPCExporter:
             # Cache constant SharedMemory offsets so export_frame() avoids per-frame arithmetic
             self._ts_offset = SHM_HEADER_SIZE + (self.num_slots * SLOT_SIZE) + SHUTDOWN_FLAG_SIZE + METADATA_SIZE
 
+            # Bind hot-path method: fast path has zero debug-branch overhead when debug=False
+            self.export_frame = self._export_frame_debug if self.debug else self._export_frame_fast
+
             self._initialized = True
             logger.info("Initialization complete — ready for zero-copy GPU transfer")
             return True
@@ -393,10 +396,51 @@ class CUDAIPCExporter:
     def export_frame(self, gpu_ptr: int, size: int) -> bool:
         """Export one frame from GPU memory via IPC ring buffer.
 
-        Call this every frame after your GPU kernel produces output.
-        For correct cross-stream ordering without CPU blocking, call
-        record_source_sync(stream_handle) immediately before this.
-        The TD Receiver will pick it up within ~16ms (1 frame at 60 FPS).
+        Bound to ``_export_frame_fast`` or ``_export_frame_debug`` after ``initialize()``.
+        Falls back to ``_export_frame_debug`` if called before initialization.
+        """
+        return self._export_frame_debug(gpu_ptr, size)
+
+    def _export_frame_fast(self, gpu_ptr: int, size: int) -> bool:
+        """Fast export path (debug=False) — zero instrumentation overhead.
+
+        Identical logic to ``_export_frame_debug`` with all ``if self.debug`` guards removed.
+        Any change to the critical path MUST be mirrored in ``_export_frame_debug``.
+        """
+        if not self._initialized:
+            logger.warning("Not initialized — call initialize() first")
+            return False
+        try:
+            slot = self.write_idx % self.num_slots
+            if self.source_sync_event is not None:
+                self.cuda.stream_wait_event(self.ipc_stream, self.source_sync_event, 0)
+            self.cuda.memcpy_async(
+                dst=self.dev_ptrs[slot],
+                src=c_void_p(gpu_ptr),
+                count=self.data_size,
+                kind=3,  # cudaMemcpyDeviceToDevice
+                stream=self.ipc_stream,
+            )
+            if self.ipc_events[slot]:
+                self.cuda.record_event(self.ipc_events[slot], stream=self.ipc_stream)
+            # See _export_frame_debug for synchronization rationale.
+            self.cuda.stream_synchronize(self.ipc_stream)
+            self.write_idx += 1
+            _ST_F64.pack_into(self.shm_handle.buf, self._ts_offset, time.perf_counter())
+            self.shm_handle.buf[self._shutdown_offset] = 0
+            _ST_U32.pack_into(self.shm_handle.buf, 16, self.write_idx)  # publish last
+            self.frame_count += 1
+            return True
+        except (OSError, RuntimeError) as e:
+            logger.error("Export failed: %s", e)
+            traceback.print_exc()
+            return False
+
+    def _export_frame_debug(self, gpu_ptr: int, size: int) -> bool:
+        """Debug export path (debug=True) — full per-operation timing instrumentation.
+
+        This is the reference implementation. Any change to the critical path MUST
+        also be applied to ``_export_frame_fast``.
 
         Args:
             gpu_ptr: Source GPU pointer (from tensor.data_ptr()).

--- a/src/cuda_link/cuda_ipc_importer.py
+++ b/src/cuda_link/cuda_ipc_importer.py
@@ -395,10 +395,6 @@ class CUDAIPCImporter:
             self._shutdown_offset = SHM_HEADER_SIZE + (self.num_slots * SLOT_SIZE)
             self._timestamp_offset = self._shutdown_offset + SHUTDOWN_FLAG_SIZE + METADATA_SIZE
 
-            # Bind hot-path methods: fast paths have zero debug-branch overhead when debug=False
-            self.get_frame = self._get_frame_debug if self.debug else self._get_frame_fast
-            self.get_frame_numpy = self._get_frame_numpy_debug if self.debug else self._get_frame_numpy_fast
-
             self._initialized = True
             logger.info("Initialization complete - ready for zero-copy GPU access")
             return True
@@ -566,60 +562,6 @@ class CUDAIPCImporter:
     def get_frame(self, stream: object | None = None) -> torch.Tensor | None:
         """Get current frame as torch.Tensor (GPU, zero-copy).
 
-        Bound to ``_get_frame_fast`` or ``_get_frame_debug`` after ``_initialize()``.
-        Falls back to ``_get_frame_debug`` if called before initialization.
-        """
-        return self._get_frame_debug(stream)
-
-    def _get_frame_fast(self, stream: object | None = None) -> torch.Tensor | None:
-        """Fast torch frame path (debug=False) — zero instrumentation overhead.
-
-        Identical logic to ``_get_frame_debug`` with all ``if self.debug`` guards removed.
-        Any change to the critical path MUST be mirrored in ``_get_frame_debug``.
-        """
-        if not TORCH_AVAILABLE:
-            raise RuntimeError("torch is required for get_frame(). Use get_frame_numpy() instead.")
-        if not self._initialized:
-            logger.warning("Not initialized - call _initialize() first")
-            return None
-        try:
-            if self.shm_handle.buf[self._shutdown_offset] == 1:
-                logger.info("Producer shutdown detected - cleaning up gracefully")
-                self.cleanup()
-                return None
-        except (OSError, BufferError) as e:
-            logger.debug("Could not read shutdown flag: %s", e)
-        current_version = _ST_U64.unpack_from(self.shm_handle.buf, VERSION_OFFSET)[0]
-        if current_version != self.ipc_version:
-            logger.debug("TD re-initialized (v%d -> v%d), reopening IPC handle...", self.ipc_version, current_version)
-            self._reinitialize()
-        read_slot = self._get_read_slot()
-        if read_slot is None:
-            return None
-        producer_timestamp = _ST_F64.unpack_from(self.shm_handle.buf, self._timestamp_offset)[0]
-        if producer_timestamp > 0:
-            self.last_latency = (time.perf_counter() - producer_timestamp) * 1000
-        else:
-            self.last_latency = 0.0
-        if stream is not None:
-            cuda_stream = self._resolve_stream(stream)
-            if self.ipc_events[read_slot]:
-                self.cuda.stream_wait_event(cuda_stream, self.ipc_events[read_slot], 0)
-        else:
-            try:
-                self._wait_for_slot(read_slot)
-            except TimeoutError:
-                logger.error("Producer timeout — returning None")
-                return None
-        self.frame_count += 1
-        return self.tensors[read_slot]
-
-    def _get_frame_debug(self, stream: object | None = None) -> torch.Tensor | None:
-        """Debug torch frame path (debug=True) — full per-operation timing instrumentation.
-
-        This is the reference implementation. Any change to the critical path MUST
-        also be applied to ``_get_frame_fast``.
-
         Args:
             stream: Optional CUDA stream (torch.cuda.Stream, cupy.cuda.Stream, int, or None).
                     If provided, issues cudaStreamWaitEvent on this stream
@@ -627,24 +569,22 @@ class CUDAIPCImporter:
                     cudaEventSynchronize for backward compatibility.
 
         Returns:
-            Zero-copy torch.Tensor on GPU, or None if not initialized
+            Zero-copy torch.Tensor on GPU, or None if not initialized or no new frame.
 
         Raises:
             RuntimeError: If torch is not available
         """
         if not TORCH_AVAILABLE:
             raise RuntimeError("torch is required for get_frame(). Use get_frame_numpy() instead.")
-
-        # Start frame timer (only if debug)
-        if self.debug:
+        debug = self.debug
+        if debug:
             frame_start = time.perf_counter()
-
         if not self._initialized:
             logger.warning("Not initialized - call _initialize() first")
             return None
 
         # Check for producer shutdown + version change + read slot (all SharedMemory reads)
-        if self.debug:
+        if debug:
             _shm_t = time.perf_counter()
         try:
             if self.shm_handle.buf[self._shutdown_offset] == 1:
@@ -664,7 +604,7 @@ class CUDAIPCImporter:
             return None  # No new frame available
 
         producer_timestamp = _ST_F64.unpack_from(self.shm_handle.buf, self._timestamp_offset)[0]
-        if self.debug:
+        if debug:
             self.total_shm_read_us += (time.perf_counter() - _shm_t) * 1_000_000
 
         if producer_timestamp > 0:  # Will be 0.0 on first frame before sender writes
@@ -673,7 +613,7 @@ class CUDAIPCImporter:
             self.last_latency = 0.0
 
         # Wait for slot to be ready (stream-ordered if stream provided, else CPU-blocking)
-        if self.debug:
+        if debug:
             wait_start = time.perf_counter()
 
         if stream is not None:
@@ -690,13 +630,13 @@ class CUDAIPCImporter:
                 logger.error("Producer timeout — returning None")
                 return None
 
-        if self.debug:
+        if debug:
             self.total_wait_event_time += (time.perf_counter() - wait_start) * 1_000_000
 
         # Frame tracking
         self.frame_count += 1
 
-        if self.debug:
+        if debug:
             frame_time = (time.perf_counter() - frame_start) * 1_000_000
             self.total_get_frame_time += frame_time
 
@@ -719,103 +659,22 @@ class CUDAIPCImporter:
     def get_frame_numpy(self) -> np.ndarray | None:
         """Get current frame as numpy array (CPU, involves D2H copy).
 
-        Bound to ``_get_frame_numpy_fast`` or ``_get_frame_numpy_debug`` after ``_initialize()``.
-        Falls back to ``_get_frame_numpy_debug`` if called before initialization.
-        """
-        return self._get_frame_numpy_debug()
-
-    def _get_frame_numpy_fast(self) -> np.ndarray | None:
-        """Fast numpy frame path (debug=False) — zero instrumentation overhead.
-
-        Identical logic to ``_get_frame_numpy_debug`` with all ``if self.debug`` guards removed.
-        Any change to the critical path MUST be mirrored in ``_get_frame_numpy_debug``.
-        """
-        if not NUMPY_AVAILABLE:
-            raise RuntimeError("numpy is required for get_frame_numpy()")
-        if not self._initialized:
-            logger.warning("Not initialized - call _initialize() first")
-            return None
-        try:
-            if self.shm_handle.buf[self._shutdown_offset] == 1:
-                logger.info("Producer shutdown detected - cleaning up gracefully")
-                self.cleanup()
-                return None
-        except (OSError, BufferError) as e:
-            logger.debug("Could not read shutdown flag: %s", e)
-        current_version = _ST_U64.unpack_from(self.shm_handle.buf, VERSION_OFFSET)[0]
-        if current_version != self.ipc_version:
-            logger.debug("TD re-initialized (v%d -> v%d), reopening IPC handle...", self.ipc_version, current_version)
-            self._reinitialize()
-        read_slot = self._get_read_slot()
-        if read_slot is None:
-            return None
-        producer_timestamp = _ST_F64.unpack_from(self.shm_handle.buf, self._timestamp_offset)[0]
-        if producer_timestamp > 0:
-            self.last_latency = (time.perf_counter() - producer_timestamp) * 1000
-        else:
-            self.last_latency = 0.0
-        height, width, channels = self.shape
-        itemsize = self._dtype_itemsize()
-        nbytes = height * width * channels * itemsize
-        if (
-            self._numpy_buffer is None
-            or self._numpy_buffer.shape != self.shape
-            or self._numpy_buffer.dtype != self._numpy_dtype()
-        ):
-            if self._pinned_ptr is not None:
-                try:
-                    self.cuda.free_host(self._pinned_ptr)
-                except (RuntimeError, OSError) as e:
-                    logger.debug("free_host failed during reshape: %s", e)
-                self._pinned_ptr = None
-            try:
-                self._pinned_ptr = self.cuda.malloc_host(nbytes)
-                buf = (ctypes.c_ubyte * nbytes).from_address(self._pinned_ptr.value)
-                self._numpy_buffer = np.frombuffer(buf, dtype=self._numpy_dtype()).reshape(self.shape)
-                logger.debug("Allocated pinned numpy buffer: %s, %s", self.shape, self.dtype)
-            except (RuntimeError, OSError) as e:
-                logger.debug("cudaMallocHost failed — falling back to pageable memory: %s", e)
-                self._numpy_buffer = np.empty(self.shape, dtype=self._numpy_dtype())
-        # See _get_frame_numpy_debug for synchronization rationale.
-        try:
-            self._wait_for_slot(read_slot)
-        except TimeoutError:
-            logger.error("Producer timeout — returning None")
-            return None
-        self.cuda.memcpy_async(
-            dst=ctypes.c_void_p(self._numpy_buffer.ctypes.data),
-            src=self.dev_ptrs[read_slot],
-            count=nbytes,
-            kind=2,  # cudaMemcpyDeviceToHost
-            stream=self._numpy_stream,
-        )
-        self.cuda.stream_synchronize(self._numpy_stream)
-        self.frame_count += 1
-        return self._numpy_buffer
-
-    def _get_frame_numpy_debug(self) -> np.ndarray | None:
-        """Debug numpy frame path (debug=True) — full per-operation timing instrumentation.
-
-        This is the reference implementation. Any change to the critical path MUST
-        also be applied to ``_get_frame_numpy_fast``.
-
         Returns:
-            Numpy array on CPU, or None if not initialized
+            Numpy array on CPU, or None if not initialized or no new frame.
 
         Raises:
             RuntimeError: If numpy is not available
         """
         if not NUMPY_AVAILABLE:
             raise RuntimeError("numpy is required for get_frame_numpy()")
-
-        if self.debug:
+        debug = self.debug
+        if debug:
             frame_start = time.perf_counter()
-
         if not self._initialized:
             logger.warning("Not initialized - call _initialize() first")
             return None
 
-        if self.debug:
+        if debug:
             _shm_t = time.perf_counter()
         try:
             if self.shm_handle.buf[self._shutdown_offset] == 1:
@@ -835,7 +694,7 @@ class CUDAIPCImporter:
             return None  # No new frame available
 
         producer_timestamp = _ST_F64.unpack_from(self.shm_handle.buf, self._timestamp_offset)[0]
-        if self.debug:
+        if debug:
             self.total_shm_read_us += (time.perf_counter() - _shm_t) * 1_000_000
 
         if producer_timestamp > 0:
@@ -877,18 +736,18 @@ class CUDAIPCImporter:
         # the IPC event BEFORE publishing write_idx (improvement #2), so the event is always
         # pre-signaled when the consumer reads write_idx — query_event returns True on the
         # first call with no polling delay.
-        if self.debug:
+        if debug:
             _wait_t = time.perf_counter()
         try:
             self._wait_for_slot(read_slot)
         except TimeoutError:
             logger.error("Producer timeout — returning None")
             return None
-        if self.debug:
+        if debug:
             self.total_wait_event_time += (time.perf_counter() - _wait_t) * 1_000_000
 
         # Async D2H copy on dedicated stream + synchronize (CPU-blocking until copy completes)
-        if self.debug:
+        if debug:
             _d2h_t = time.perf_counter()
         self.cuda.memcpy_async(
             dst=ctypes.c_void_p(self._numpy_buffer.ctypes.data),
@@ -898,13 +757,13 @@ class CUDAIPCImporter:
             stream=self._numpy_stream,
         )
         self.cuda.stream_synchronize(self._numpy_stream)
-        if self.debug:
+        if debug:
             d2h_time = (time.perf_counter() - _d2h_t) * 1_000_000
 
         # Frame tracking
         self.frame_count += 1
 
-        if self.debug:
+        if debug:
             frame_time = (time.perf_counter() - frame_start) * 1_000_000
             self.total_get_frame_time += frame_time
 

--- a/src/cuda_link/cuda_ipc_importer.py
+++ b/src/cuda_link/cuda_ipc_importer.py
@@ -73,6 +73,11 @@ METADATA_SIZE = 20  # 4B width + 4B height + 4B num_comps + 4B dtype_code + 4B b
 TIMESTAMP_SIZE = 8  # 8B float64 producer timestamp (for latency measurement)
 # TIMESTAMP_OFFSET calculated at runtime: SHM_HEADER_SIZE + (num_slots * SLOT_SIZE) + SHUTDOWN_FLAG_SIZE + METADATA_SIZE
 
+# Pre-compiled struct objects for hot-path SHM reads (~50-100ns saved per call vs format-string lookup)
+_ST_U32 = struct.Struct("<I")  # uint32 LE (write_idx, num_slots, metadata fields)
+_ST_U64 = struct.Struct("<Q")  # uint64 LE (version)
+_ST_F64 = struct.Struct("<d")  # float64 LE (timestamp)
+
 
 class CUDAIPCImporter:
     """Python-side importer for CUDA IPC GPU memory.
@@ -499,7 +504,7 @@ class CUDAIPCImporter:
         Returns:
             Slot index to read from, or None if no new frame available
         """
-        write_idx = struct.unpack_from("<I", self.shm_handle.buf, WRITE_IDX_OFFSET)[0]
+        write_idx = _ST_U32.unpack_from(self.shm_handle.buf, WRITE_IDX_OFFSET)[0]
 
         if write_idx == 0:
             return None  # No frames written yet
@@ -582,7 +587,7 @@ class CUDAIPCImporter:
         except (OSError, BufferError) as e:
             logger.debug("Could not read shutdown flag: %s", e)
 
-        current_version = struct.unpack_from("<Q", self.shm_handle.buf, VERSION_OFFSET)[0]
+        current_version = _ST_U64.unpack_from(self.shm_handle.buf, VERSION_OFFSET)[0]
         if current_version != self.ipc_version:
             logger.debug("TD re-initialized (v%d -> v%d), reopening IPC handle...", self.ipc_version, current_version)
             self._reinitialize()
@@ -591,7 +596,7 @@ class CUDAIPCImporter:
         if read_slot is None:
             return None  # No new frame available
 
-        producer_timestamp = struct.unpack_from("<d", self.shm_handle.buf, self._timestamp_offset)[0]
+        producer_timestamp = _ST_F64.unpack_from(self.shm_handle.buf, self._timestamp_offset)[0]
         if self.debug:
             self.total_shm_read_us += (time.perf_counter() - _shm_t) * 1_000_000
 
@@ -656,7 +661,6 @@ class CUDAIPCImporter:
         if not NUMPY_AVAILABLE:
             raise RuntimeError("numpy is required for get_frame_numpy()")
 
-        # Start frame timer (only if debug)
         if self.debug:
             frame_start = time.perf_counter()
 
@@ -664,7 +668,6 @@ class CUDAIPCImporter:
             logger.warning("Not initialized - call _initialize() first")
             return None
 
-        # Check for producer shutdown + version change + read slot (all SharedMemory reads)
         if self.debug:
             _shm_t = time.perf_counter()
         try:
@@ -675,7 +678,7 @@ class CUDAIPCImporter:
         except (OSError, BufferError) as e:
             logger.debug("Could not read shutdown flag: %s", e)
 
-        current_version = struct.unpack_from("<Q", self.shm_handle.buf, VERSION_OFFSET)[0]
+        current_version = _ST_U64.unpack_from(self.shm_handle.buf, VERSION_OFFSET)[0]
         if current_version != self.ipc_version:
             logger.debug("TD re-initialized (v%d -> v%d), reopening IPC handle...", self.ipc_version, current_version)
             self._reinitialize()
@@ -684,27 +687,15 @@ class CUDAIPCImporter:
         if read_slot is None:
             return None  # No new frame available
 
-        producer_timestamp = struct.unpack_from("<d", self.shm_handle.buf, self._timestamp_offset)[0]
+        producer_timestamp = _ST_F64.unpack_from(self.shm_handle.buf, self._timestamp_offset)[0]
         if self.debug:
             self.total_shm_read_us += (time.perf_counter() - _shm_t) * 1_000_000
 
-        if producer_timestamp > 0:  # Will be 0.0 on first frame before sender writes
+        if producer_timestamp > 0:
             self.last_latency = (time.perf_counter() - producer_timestamp) * 1000
         else:
             self.last_latency = 0.0
 
-        # Wait for slot to be ready (CPU-blocking poll + event query)
-        if self.debug:
-            _wait_t = time.perf_counter()
-        try:
-            self._wait_for_slot(read_slot)
-        except TimeoutError:
-            logger.error("Producer timeout — returning None")
-            return None
-        if self.debug:
-            self.total_wait_event_time += (time.perf_counter() - _wait_t) * 1_000_000
-
-        # D2H copy via CUDA memcpy (inherently not zero-copy)
         height, width, channels = self.shape
         itemsize = self._dtype_itemsize()
         nbytes = height * width * channels * itemsize
@@ -731,6 +722,23 @@ class CUDAIPCImporter:
             except (RuntimeError, OSError) as e:
                 logger.debug("cudaMallocHost failed — falling back to pageable memory: %s", e)
                 self._numpy_buffer = np.empty(self.shape, dtype=self._numpy_dtype())
+
+        # CPU-side event poll + async D2H + synchronize.
+        # Uses _wait_for_slot (query_event CPU poll) rather than stream_wait_event because
+        # cudaStreamWaitEvent on a cross-process IPC event has high kernel-mode latency on
+        # Windows (~100-300ms when followed by stream_synchronize). The producer records
+        # the IPC event BEFORE publishing write_idx (improvement #2), so the event is always
+        # pre-signaled when the consumer reads write_idx — query_event returns True on the
+        # first call with no polling delay.
+        if self.debug:
+            _wait_t = time.perf_counter()
+        try:
+            self._wait_for_slot(read_slot)
+        except TimeoutError:
+            logger.error("Producer timeout — returning None")
+            return None
+        if self.debug:
+            self.total_wait_event_time += (time.perf_counter() - _wait_t) * 1_000_000
 
         # Async D2H copy on dedicated stream + synchronize (CPU-blocking until copy completes)
         if self.debug:
@@ -798,7 +806,7 @@ class CUDAIPCImporter:
         except (OSError, BufferError) as e:
             logger.debug("Could not read shutdown flag: %s", e)
 
-        current_version = struct.unpack_from("<Q", self.shm_handle.buf, VERSION_OFFSET)[0]
+        current_version = _ST_U64.unpack_from(self.shm_handle.buf, VERSION_OFFSET)[0]
         if current_version != self.ipc_version:
             logger.debug("TD re-initialized (v%d -> v%d), reopening IPC handle...", self.ipc_version, current_version)
             self._reinitialize()
@@ -807,7 +815,7 @@ class CUDAIPCImporter:
         if read_slot is None:
             return None  # No new frame available
 
-        producer_timestamp = struct.unpack_from("<d", self.shm_handle.buf, self._timestamp_offset)[0]
+        producer_timestamp = _ST_F64.unpack_from(self.shm_handle.buf, self._timestamp_offset)[0]
         if producer_timestamp > 0:  # Will be 0.0 on first frame before sender writes
             self.last_latency = (time.perf_counter() - producer_timestamp) * 1000
         else:

--- a/src/cuda_link/cuda_ipc_importer.py
+++ b/src/cuda_link/cuda_ipc_importer.py
@@ -170,7 +170,7 @@ class CUDAIPCImporter:
         """Get byte size per element for the configured dtype."""
         return _DTYPE_SIZES[self.dtype]
 
-    def _numpy_dtype(self) -> "np.dtype":
+    def _numpy_dtype(self) -> np.dtype:
         """Get numpy dtype from string dtype."""
         if not NUMPY_AVAILABLE:
             raise RuntimeError("numpy is required but not installed")

--- a/src/cuda_link/cuda_ipc_importer.py
+++ b/src/cuda_link/cuda_ipc_importer.py
@@ -386,6 +386,10 @@ class CUDAIPCImporter:
             self._shutdown_offset = SHM_HEADER_SIZE + (self.num_slots * SLOT_SIZE)
             self._timestamp_offset = self._shutdown_offset + SHUTDOWN_FLAG_SIZE + METADATA_SIZE
 
+            # Bind hot-path methods: fast paths have zero debug-branch overhead when debug=False
+            self.get_frame = self._get_frame_debug if self.debug else self._get_frame_fast
+            self.get_frame_numpy = self._get_frame_numpy_debug if self.debug else self._get_frame_numpy_fast
+
             self._initialized = True
             logger.info("Initialization complete - ready for zero-copy GPU access")
             return True
@@ -553,6 +557,60 @@ class CUDAIPCImporter:
     def get_frame(self, stream: object | None = None) -> torch.Tensor | None:
         """Get current frame as torch.Tensor (GPU, zero-copy).
 
+        Bound to ``_get_frame_fast`` or ``_get_frame_debug`` after ``_initialize()``.
+        Falls back to ``_get_frame_debug`` if called before initialization.
+        """
+        return self._get_frame_debug(stream)
+
+    def _get_frame_fast(self, stream: object | None = None) -> torch.Tensor | None:
+        """Fast torch frame path (debug=False) — zero instrumentation overhead.
+
+        Identical logic to ``_get_frame_debug`` with all ``if self.debug`` guards removed.
+        Any change to the critical path MUST be mirrored in ``_get_frame_debug``.
+        """
+        if not TORCH_AVAILABLE:
+            raise RuntimeError("torch is required for get_frame(). Use get_frame_numpy() instead.")
+        if not self._initialized:
+            logger.warning("Not initialized - call _initialize() first")
+            return None
+        try:
+            if self.shm_handle.buf[self._shutdown_offset] == 1:
+                logger.info("Producer shutdown detected - cleaning up gracefully")
+                self.cleanup()
+                return None
+        except (OSError, BufferError) as e:
+            logger.debug("Could not read shutdown flag: %s", e)
+        current_version = _ST_U64.unpack_from(self.shm_handle.buf, VERSION_OFFSET)[0]
+        if current_version != self.ipc_version:
+            logger.debug("TD re-initialized (v%d -> v%d), reopening IPC handle...", self.ipc_version, current_version)
+            self._reinitialize()
+        read_slot = self._get_read_slot()
+        if read_slot is None:
+            return None
+        producer_timestamp = _ST_F64.unpack_from(self.shm_handle.buf, self._timestamp_offset)[0]
+        if producer_timestamp > 0:
+            self.last_latency = (time.perf_counter() - producer_timestamp) * 1000
+        else:
+            self.last_latency = 0.0
+        if stream is not None:
+            cuda_stream = self._resolve_stream(stream)
+            if self.ipc_events[read_slot]:
+                self.cuda.stream_wait_event(cuda_stream, self.ipc_events[read_slot], 0)
+        else:
+            try:
+                self._wait_for_slot(read_slot)
+            except TimeoutError:
+                logger.error("Producer timeout — returning None")
+                return None
+        self.frame_count += 1
+        return self.tensors[read_slot]
+
+    def _get_frame_debug(self, stream: object | None = None) -> torch.Tensor | None:
+        """Debug torch frame path (debug=True) — full per-operation timing instrumentation.
+
+        This is the reference implementation. Any change to the critical path MUST
+        also be applied to ``_get_frame_fast``.
+
         Args:
             stream: Optional CUDA stream (torch.cuda.Stream, cupy.cuda.Stream, int, or None).
                     If provided, issues cudaStreamWaitEvent on this stream
@@ -651,6 +709,86 @@ class CUDAIPCImporter:
 
     def get_frame_numpy(self) -> np.ndarray | None:
         """Get current frame as numpy array (CPU, involves D2H copy).
+
+        Bound to ``_get_frame_numpy_fast`` or ``_get_frame_numpy_debug`` after ``_initialize()``.
+        Falls back to ``_get_frame_numpy_debug`` if called before initialization.
+        """
+        return self._get_frame_numpy_debug()
+
+    def _get_frame_numpy_fast(self) -> np.ndarray | None:
+        """Fast numpy frame path (debug=False) — zero instrumentation overhead.
+
+        Identical logic to ``_get_frame_numpy_debug`` with all ``if self.debug`` guards removed.
+        Any change to the critical path MUST be mirrored in ``_get_frame_numpy_debug``.
+        """
+        if not NUMPY_AVAILABLE:
+            raise RuntimeError("numpy is required for get_frame_numpy()")
+        if not self._initialized:
+            logger.warning("Not initialized - call _initialize() first")
+            return None
+        try:
+            if self.shm_handle.buf[self._shutdown_offset] == 1:
+                logger.info("Producer shutdown detected - cleaning up gracefully")
+                self.cleanup()
+                return None
+        except (OSError, BufferError) as e:
+            logger.debug("Could not read shutdown flag: %s", e)
+        current_version = _ST_U64.unpack_from(self.shm_handle.buf, VERSION_OFFSET)[0]
+        if current_version != self.ipc_version:
+            logger.debug("TD re-initialized (v%d -> v%d), reopening IPC handle...", self.ipc_version, current_version)
+            self._reinitialize()
+        read_slot = self._get_read_slot()
+        if read_slot is None:
+            return None
+        producer_timestamp = _ST_F64.unpack_from(self.shm_handle.buf, self._timestamp_offset)[0]
+        if producer_timestamp > 0:
+            self.last_latency = (time.perf_counter() - producer_timestamp) * 1000
+        else:
+            self.last_latency = 0.0
+        height, width, channels = self.shape
+        itemsize = self._dtype_itemsize()
+        nbytes = height * width * channels * itemsize
+        if (
+            self._numpy_buffer is None
+            or self._numpy_buffer.shape != self.shape
+            or self._numpy_buffer.dtype != self._numpy_dtype()
+        ):
+            if self._pinned_ptr is not None:
+                try:
+                    self.cuda.free_host(self._pinned_ptr)
+                except (RuntimeError, OSError) as e:
+                    logger.debug("free_host failed during reshape: %s", e)
+                self._pinned_ptr = None
+            try:
+                self._pinned_ptr = self.cuda.malloc_host(nbytes)
+                buf = (ctypes.c_ubyte * nbytes).from_address(self._pinned_ptr.value)
+                self._numpy_buffer = np.frombuffer(buf, dtype=self._numpy_dtype()).reshape(self.shape)
+                logger.debug("Allocated pinned numpy buffer: %s, %s", self.shape, self.dtype)
+            except (RuntimeError, OSError) as e:
+                logger.debug("cudaMallocHost failed — falling back to pageable memory: %s", e)
+                self._numpy_buffer = np.empty(self.shape, dtype=self._numpy_dtype())
+        # See _get_frame_numpy_debug for synchronization rationale.
+        try:
+            self._wait_for_slot(read_slot)
+        except TimeoutError:
+            logger.error("Producer timeout — returning None")
+            return None
+        self.cuda.memcpy_async(
+            dst=ctypes.c_void_p(self._numpy_buffer.ctypes.data),
+            src=self.dev_ptrs[read_slot],
+            count=nbytes,
+            kind=2,  # cudaMemcpyDeviceToHost
+            stream=self._numpy_stream,
+        )
+        self.cuda.stream_synchronize(self._numpy_stream)
+        self.frame_count += 1
+        return self._numpy_buffer
+
+    def _get_frame_numpy_debug(self) -> np.ndarray | None:
+        """Debug numpy frame path (debug=True) — full per-operation timing instrumentation.
+
+        This is the reference implementation. Any change to the critical path MUST
+        also be applied to ``_get_frame_numpy_fast``.
 
         Returns:
             Numpy array on CPU, or None if not initialized

--- a/src/cuda_link/cuda_ipc_importer.py
+++ b/src/cuda_link/cuda_ipc_importer.py
@@ -56,6 +56,9 @@ except ImportError:
 
 from .cuda_ipc_wrapper import cudaIpcEventHandle_t, cudaIpcMemHandle_t, get_cuda_runtime  # noqa: E402
 
+# Byte size per dtype — module-level constant avoids dict construction on every _dtype_itemsize() call
+_DTYPE_SIZES: dict = {"float32": 4, "float16": 2, "uint8": 1, "uint16": 2}
+
 # Protocol layout constants (must match td_exporter/CUDAIPCExtension.py)
 PROTOCOL_MAGIC = 0x43495043  # "CIPC" - protocol validation magic number
 MAGIC_OFFSET = 0
@@ -156,19 +159,25 @@ class CUDAIPCImporter:
         self._shutdown_offset: int = 0
         self._timestamp_offset: int = 0
 
+        # Cached dtype-derived values — avoids np.dtype() construction per frame
+        self._cached_dtype_str: str = ""
+        self._cached_numpy_dtype: object = None
+
         # Auto-initialize
         self._initialize()
 
     def _dtype_itemsize(self) -> int:
         """Get byte size per element for the configured dtype."""
-        sizes = {"float32": 4, "float16": 2, "uint8": 1, "uint16": 2}
-        return sizes[self.dtype]
+        return _DTYPE_SIZES[self.dtype]
 
-    def _numpy_dtype(self) -> np.dtype:
+    def _numpy_dtype(self) -> "np.dtype":
         """Get numpy dtype from string dtype."""
         if not NUMPY_AVAILABLE:
             raise RuntimeError("numpy is required but not installed")
-        return np.dtype(self.dtype)
+        if self.dtype != getattr(self, "_cached_dtype_str", ""):
+            self._cached_numpy_dtype = np.dtype(self.dtype)
+            self._cached_dtype_str = self.dtype
+        return self._cached_numpy_dtype
 
     def _torch_dtype(self) -> torch.dtype:
         """Get torch dtype from string dtype."""

--- a/src/cuda_link/cuda_ipc_wrapper.py
+++ b/src/cuda_link/cuda_ipc_wrapper.py
@@ -701,6 +701,48 @@ class CUDARuntimeAPI:
         self.check_error(result, "cudaMemGetInfo")
         return free.value, total.value
 
+    def stream_query(self, stream: CUDAStream_t) -> bool:
+        """Non-blocking check if all operations on stream have completed.
+
+        Args:
+            stream: CUDA stream to query
+
+        Returns:
+            True if all stream operations have completed, False if still executing
+
+        Raises:
+            RuntimeError: If query fails with an error other than cudaErrorNotReady
+        """
+        result = self.cudart.cudaStreamQuery(stream)
+        if result == 0:  # cudaSuccess
+            return True
+        if result == 600:  # cudaErrorNotReady
+            return False
+        self.check_error(result, "cudaStreamQuery")
+        return False  # unreachable
+
+    def device_can_access_peer(self, device: int, peer_device: int) -> bool:
+        """Check if device can directly access peer_device memory via IPC/NVLink.
+
+        Useful for validating multi-GPU setups before attempting IPC handle operations.
+        On single-GPU systems or systems without peer access, cudaIpcOpenMemHandle
+        may fall back to slower paths without warning.
+
+        Args:
+            device: Source device ID
+            peer_device: Target peer device ID
+
+        Returns:
+            True if direct peer access is available, False otherwise
+
+        Raises:
+            RuntimeError: If query fails
+        """
+        can_access = c_int(0)
+        result = self.cudart.cudaDeviceCanAccessPeer(byref(can_access), device, peer_device)
+        self.check_error(result, "cudaDeviceCanAccessPeer")
+        return bool(can_access.value)
+
 
 # Global singleton instance (lazy initialization)
 _cuda_runtime: CUDARuntimeAPI | None = None

--- a/src/cuda_link/cuda_ipc_wrapper.py
+++ b/src/cuda_link/cuda_ipc_wrapper.py
@@ -288,6 +288,14 @@ class CUDARuntimeAPI:
         self.cudart.cudaGetDevice.argtypes = [POINTER(c_int)]
         self.cudart.cudaGetDevice.restype = c_int
 
+        # cudaStreamQuery(cudaStream_t stream)
+        self.cudart.cudaStreamQuery.argtypes = [CUDAStream_t]
+        self.cudart.cudaStreamQuery.restype = c_int
+
+        # cudaDeviceCanAccessPeer(int* canAccessPeer, int device, int peerDevice)
+        self.cudart.cudaDeviceCanAccessPeer.argtypes = [POINTER(c_int), c_int, c_int]
+        self.cudart.cudaDeviceCanAccessPeer.restype = c_int
+
     def check_error(self, result: int, operation: str) -> None:
         """Check CUDA error code and raise exception if failed.
 

--- a/src/cuda_link/cuda_ipc_wrapper.py
+++ b/src/cuda_link/cuda_ipc_wrapper.py
@@ -54,6 +54,7 @@ class CUDAError:
     INVALID_DEVICE_POINTER = 17
     INVALID_DEVICE = 101
     INVALID_CONTEXT = 201  # Common in same-process IPC testing
+    NOT_READY = 600
     PEER_ACCESS_ALREADY_ENABLED = 704
 
     @staticmethod
@@ -66,6 +67,7 @@ class CUDAError:
             17: "INVALID_DEVICE_POINTER",
             101: "INVALID_DEVICE",
             201: "INVALID_CONTEXT",
+            600: "NOT_READY",
             704: "PEER_ACCESS_ALREADY_ENABLED",
         }
         return names.get(code, f"UNKNOWN_ERROR_{code}")
@@ -497,7 +499,7 @@ class CUDARuntimeAPI:
         result = self.cudart.cudaEventQuery(event)
         if result == CUDAError.SUCCESS:
             return True
-        elif result == 600:  # cudaErrorNotReady
+        elif result == CUDAError.NOT_READY:
             return False
         self.check_error(result, "cudaEventQuery")
         return False
@@ -722,9 +724,9 @@ class CUDARuntimeAPI:
             RuntimeError: If query fails with an error other than cudaErrorNotReady
         """
         result = self.cudart.cudaStreamQuery(stream)
-        if result == 0:  # cudaSuccess
+        if result == CUDAError.SUCCESS:
             return True
-        if result == 600:  # cudaErrorNotReady
+        if result == CUDAError.NOT_READY:
             return False
         self.check_error(result, "cudaStreamQuery")
         return False  # unreachable

--- a/td_exporter/CUDAIPCExtension.py
+++ b/td_exporter/CUDAIPCExtension.py
@@ -222,6 +222,11 @@ class CUDAIPCExtension:
         self._fmt_conv_active = False
         # Cached dtype_converter Transform TOP reference (stable; refreshed on initialize())
         self._fmt_transform: object = None
+        # Cached ExportBuffer TOP reference — eliminates per-frame ownerComp.op() lookup (same pattern as _fmt_transform)
+        self._export_buffer: object = None
+        # Format conversion result cache — avoid .lower() + set scan when pixel format unchanged
+        self._last_pixel_fmt: str = ""
+        self._last_fmt_needs_conv: bool = False
 
         # Lazy attributes — pre-initialized here to avoid per-frame hasattr()/getattr() fallbacks
         self.ipc_stream = None  # Created on first export_frame() or initialize()
@@ -266,8 +271,13 @@ class CUDAIPCExtension:
         TD 2025 (CUDA 12.8) rejects float16 formats from cudaMemory().
         uint8, uint16 (fixed), and float32 are supported.
         """
-        pixel_fmt = str(getattr(top_op, "pixelFormat", "")).lower()
-        return any(unsupported in pixel_fmt for unsupported in _CUDA_UNSUPPORTED_PIXEL_FORMATS)
+        pixel_fmt = str(getattr(top_op, "pixelFormat", ""))
+        if pixel_fmt == self._last_pixel_fmt:
+            return self._last_fmt_needs_conv
+        self._last_pixel_fmt = pixel_fmt
+        pixel_lower = pixel_fmt.lower()
+        self._last_fmt_needs_conv = any(u in pixel_lower for u in _CUDA_UNSUPPORTED_PIXEL_FORMATS)
+        return self._last_fmt_needs_conv
 
     def switch_mode(self, new_mode: str) -> None:
         """Switch between Sender and Receiver modes.
@@ -417,6 +427,8 @@ class CUDAIPCExtension:
 
             # Cache dtype_converter TOP reference — eliminates per-frame ownerComp.op() lookup
             self._fmt_transform = self.ownerComp.op(_FMT_TRANSFORM_NAME)
+            # Cache ExportBuffer TOP reference — eliminates per-frame ownerComp.op() lookup (same pattern)
+            self._export_buffer = self.ownerComp.op(_EXPORT_BUFFER_NAME)
 
             # Create GPU timing events (only when Debug is ON for benchmarking)
             if self.verbose_performance:
@@ -601,10 +613,14 @@ class CUDAIPCExtension:
         Returns:
             True if export successful, False otherwise
         """
-        top_op = self.ownerComp.op(_EXPORT_BUFFER_NAME)
+        top_op = self._export_buffer
         if top_op is None:
-            self._log(f"'{_EXPORT_BUFFER_NAME}' not found in component", force=True)
-            return False
+            # Lazy lookup: op may have been added after initialize() (e.g. dynamic network edits)
+            top_op = self.ownerComp.op(_EXPORT_BUFFER_NAME)
+            if top_op is None:
+                self._log(f"'{_EXPORT_BUFFER_NAME}' not found in component", force=True)
+                return False
+            self._export_buffer = top_op  # cache for subsequent frames
 
         # Check if Active parameter is enabled (use cached par ref to avoid 3-deep chain per frame)
         if self._active_par is not None and not bool(self._active_par.eval()):
@@ -693,7 +709,10 @@ class CUDAIPCExtension:
             actual_channels = shape.numComps
             actual_size = cuda_mem.size
             # CUDAMemoryShape.dataType returns numpy.dtype — more reliable than byte-ratio inference
-            self._detected_numpy_dtype = getattr(shape, "dataType", None)
+            try:
+                self._detected_numpy_dtype = shape.dataType
+            except AttributeError:
+                self._detected_numpy_dtype = None
 
             # Check if we need to (re)initialize
             if not self._initialized or actual_size != self.data_size:
@@ -1026,8 +1045,6 @@ class CUDAIPCExtension:
         # Unlink SharedMemory (sender is owner and should clean up)
         if hasattr(self, "shm_name"):
             try:
-                from multiprocessing.shared_memory import SharedMemory
-
                 try:
                     shm_temp = SharedMemory(name=self.shm_name)
                     shm_temp.close()
@@ -1047,6 +1064,8 @@ class CUDAIPCExtension:
         self.ipc_stream = None
         self.shm_handle = None
         self._fmt_conv_active = False
+        self._export_buffer = None
+        self._fmt_transform = None
 
         # Reset per-session counters so averages are accurate after reinit
         # and slot selection starts from 0 (matching SharedMemory write_idx=0 written on init).
@@ -1173,11 +1192,9 @@ class CUDAIPCExtension:
                     if self._rx_f16_cpu_buf is None or self._rx_f32_cpu_buf is None:
                         debug("[CUDAIPCLink] float16 CPU buffers not allocated — skipping frame")
                         return False
-                    import ctypes
-                    from ctypes import c_void_p
 
                     # D2H on _rx_stream: stream_wait_event (enqueued earlier) guarantees data is ready.
-                    cpu_ptr = self._rx_f16_cpu_buf.ctypes.data_as(ctypes.c_void_p)
+                    cpu_ptr = self._rx_f16_cpu_buf.ctypes.data_as(c_void_p)
                     self.cuda.memcpy_async(cpu_ptr, c_void_p(address), self._rx_buffer_size, 2, self._rx_stream)
                     self.cuda.stream_synchronize(self._rx_stream)
                     numpy.copyto(

--- a/td_exporter/CUDAIPCExtension.py
+++ b/td_exporter/CUDAIPCExtension.py
@@ -648,6 +648,13 @@ class CUDAIPCExtension:
             if fmt_transform is not None and not getattr(fmt_transform, "valid", True):
                 self._fmt_transform = None
                 fmt_transform = None
+            if fmt_transform is None:
+                # Lazy lookup: initialize() may not have run yet (pre-init export_frame() path).
+                # Without this, float16 sources are permanently stuck — cudaMemory() fails before
+                # auto-init at line 719 is reached. Same pattern as _export_buffer lazy fallback.
+                fmt_transform = self.ownerComp.op(_FMT_TRANSFORM_NAME)
+                if fmt_transform is not None:
+                    self._fmt_transform = fmt_transform
             if fmt_transform is not None:
                 source_top = fmt_transform.inputs[0] if fmt_transform.inputs else top_op
                 if self._needs_format_conversion(source_top):

--- a/td_exporter/CUDAIPCExtension.py
+++ b/td_exporter/CUDAIPCExtension.py
@@ -25,6 +25,14 @@ try:
 except ImportError:
     numpy = None  # Will be imported at runtime in TD
 
+try:
+    import cupy as cp
+
+    CUPY_AVAILABLE = True
+except ImportError:
+    cp = None
+    CUPY_AVAILABLE = False
+
 # Import types with fallbacks
 try:
     from td import COMP, TOP, CUDAMemoryShape
@@ -63,6 +71,11 @@ DTYPE_FLOAT16 = 1
 DTYPE_UINT8 = 2
 DTYPE_UINT16 = 3
 
+# Pre-compiled struct objects for hot-path SHM reads/writes (~50-100ns saved per call vs format-string lookup)
+_ST_U32 = struct.Struct("<I")  # uint32 LE (write_idx, num_slots, metadata fields)
+_ST_U64 = struct.Struct("<Q")  # uint64 LE (version)
+_ST_F64 = struct.Struct("<d")  # float64 LE (timestamp)
+
 # Pixel format substrings that TD 2025 (CUDA 12.8) rejects in cudaMemory().
 # uint8 / uint16 (fixed) and float32 are supported. float16 variants are not.
 _CUDA_UNSUPPORTED_PIXEL_FORMATS = {"16-bit float", "16float"}
@@ -89,7 +102,7 @@ class CUDAIPCExtension:
     - Per frame: wait on GPU event, call scriptTOP.copyCUDAMemory()
 
     Performance:
-    - Sender per-frame: ~3-8μs IPC primitives + async D2D enqueue (~60-80μs GPU-side for 1080p)
+    - Sender per-frame: ~10-20μs within TD CUDA context; ~177-219μs in standalone Python (WDDM + stream_synchronize)
     - Receiver per-frame: < 5μs (event sync enqueue + copyCUDAMemory call)
     - Zero CPU memory copies (GPU-direct)
     """
@@ -150,6 +163,10 @@ class CUDAIPCExtension:
             # Fallback to default name if parameter doesn't exist
             self.shm_name = "cudalink_output_ipc"
 
+        # Cached SHM byte offsets — computed once in initialize() to avoid per-frame arithmetic
+        self._shutdown_offset = 0  # SHM_HEADER_SIZE + num_slots * SLOT_SIZE
+        self._ts_offset = 0  # _shutdown_offset + SHUTDOWN_FLAG_SIZE + METADATA_SIZE
+
         # Frame tracking
         self.frame_count = 0
 
@@ -181,6 +198,7 @@ class CUDAIPCExtension:
         self._rx_ipc_events = [None] * self.num_slots  # Opened IPC events
         self._rx_ipc_version = 0
         self._rx_num_slots = 0
+        self._rx_shutdown_offset = 0  # Cached: SHM_HEADER_SIZE + _rx_num_slots * SLOT_SIZE
         self._rx_width = 0
         self._rx_height = 0
         self._rx_num_comps = 0
@@ -198,6 +216,7 @@ class CUDAIPCExtension:
         self._rx_f16_cpu_buf = None  # float16 CPU buffer for D2H conversion (float16 IPC only)
         self._rx_f32_cpu_buf = None  # float32 CPU buffer after conversion (float16 IPC only)
         self._rx_f16_pinned_ptr = None  # cudaMallocHost pointer backing _rx_f16_cpu_buf (or None if pageable)
+        self._rx_cupy_f32_buf = None  # float32 CuPy GPU buffer for GPU-side f16→f32 (CuPy path, float16 IPC only)
 
         # Format conversion state — True when dtype_converter is set to rgba32float
         self._fmt_conv_active = False
@@ -375,6 +394,10 @@ class CUDAIPCExtension:
 
             # Write texture metadata to extended protocol region
             self._write_metadata_to_shm()
+
+            # Cache SHM offsets: avoid recomputing these on every export_frame() call
+            self._shutdown_offset = SHM_HEADER_SIZE + (self.num_slots * SLOT_SIZE)
+            self._ts_offset = self._shutdown_offset + SHUTDOWN_FLAG_SIZE + METADATA_SIZE
 
             # Create GPU timing events (only when Debug is ON for benchmarking)
             if self.verbose_performance:
@@ -736,22 +759,25 @@ class CUDAIPCExtension:
                     record_event_time = (time.perf_counter() - record_start) * 1_000_000
                     self.total_record_event_time += record_event_time
 
+                # Synchronize ipc_stream: ensures D2D copy + event record have completed on
+                # the GPU before write_idx is published. Guarantees the IPC event is pre-signaled
+                # when the consumer reads write_idx, so query_event() returns True immediately
+                # (no polling delay). Cost: ~D2D GPU time per frame (~13us at 512x512).
+                self.cuda.stream_synchronize(self.ipc_stream)
+
                 # Always write producer timestamp (enables consumer latency measurement)
-                timestamp_offset = SHM_HEADER_SIZE + (self.num_slots * SLOT_SIZE) + SHUTDOWN_FLAG_SIZE + METADATA_SIZE
-                struct.pack_into("<d", self.shm_handle.buf, timestamp_offset, time.perf_counter())
+                _ST_F64.pack_into(self.shm_handle.buf, self._ts_offset, time.perf_counter())
             else:
                 # FALLBACK: Conditional CPU synchronization
                 if self.frame_count % self.sync_interval == 0:
                     self.cuda.synchronize()
 
-            # Update write_idx and reassert shutdown_flag=0 in SharedMemory.
-            # The shutdown_flag write costs 1 byte and prevents a stale flag=1 from
-            # a previous cleanup (or another process that shared this SharedMemory name)
-            # from blocking the receiver.
+            # Publish write_idx LAST: clear shutdown_flag first so the consumer
+            # (which reads shutdown_flag before write_idx) always sees flag=0
+            # when it detects a new frame (atomicity improvement).
             self.write_idx += 1
-            struct.pack_into("<I", self.shm_handle.buf, WRITE_IDX_OFFSET, self.write_idx)
-            shutdown_offset = SHM_HEADER_SIZE + (self.num_slots * SLOT_SIZE)
-            self.shm_handle.buf[shutdown_offset] = 0
+            self.shm_handle.buf[self._shutdown_offset] = 0
+            _ST_U32.pack_into(self.shm_handle.buf, WRITE_IDX_OFFSET, self.write_idx)  # publish last
 
             # Frame tracking
             self.frame_count += 1
@@ -1061,14 +1087,13 @@ class CUDAIPCExtension:
 
         try:
             # Check for shutdown signal
-            shutdown_offset = SHM_HEADER_SIZE + (self._rx_num_slots * SLOT_SIZE)
-            if self.shm_handle.buf[shutdown_offset] == 1:
+            if self.shm_handle.buf[self._rx_shutdown_offset] == 1:
                 self._log("Sender shutdown detected. Cleaning up.", force=True)
                 self.cleanup_receiver()
                 return False
 
             # Check for version change (sender re-initialized)
-            current_version = struct.unpack_from("<Q", self.shm_handle.buf, VERSION_OFFSET)[0]
+            current_version = _ST_U64.unpack_from(self.shm_handle.buf, VERSION_OFFSET)[0]
             if current_version != self._rx_ipc_version:
                 self._log(
                     f"Sender re-initialized (v{self._rx_ipc_version} -> v{current_version}). Reconnecting...",
@@ -1078,7 +1103,7 @@ class CUDAIPCExtension:
                 return False  # Will reinitialize on next frame
 
             # Read write_idx and calculate read slot
-            write_idx = struct.unpack_from("<I", self.shm_handle.buf, WRITE_IDX_OFFSET)[0]
+            write_idx = _ST_U32.unpack_from(self.shm_handle.buf, WRITE_IDX_OFFSET)[0]
             if write_idx == 0:
                 return False  # No frames written yet
 
@@ -1101,27 +1126,53 @@ class CUDAIPCExtension:
             address = self._rx_dev_ptrs[read_slot].value
 
             if self._rx_dtype_code == DTYPE_FLOAT16:
-                # copyCUDAMemory doesn't support float16 — D2H + convert + copyNumpyArray
-                if self._rx_f16_cpu_buf is None or self._rx_f32_cpu_buf is None:
-                    debug("[CUDAIPCLink] float16 CPU buffers not allocated — skipping frame")
-                    return False
-                import ctypes
-                from ctypes import c_void_p
+                if CUPY_AVAILABLE and self._rx_cupy_f32_buf is not None:
+                    # GPU-side float16→float32 conversion (Ch5: minimize PCIe traffic).
+                    # stream_wait_event (enqueued above on _rx_stream) guarantees GPU data is ready.
+                    # We create a zero-copy CuPy view of the IPC pointer, run an elementwise
+                    # f16→f32 cast entirely on GPU via ExternalStream, then call copyCUDAMemory —
+                    # eliminating two PCIe roundtrips and the CPU numpy.copyto call.
+                    rx_stream_int = int(self._rx_stream.value)
+                    f16_size = self._rx_buffer_size  # original float16 byte count
+                    f32_size = f16_size * 2  # float32 = 2× bytes
 
-                # D2H on _rx_stream: stream_wait_event (enqueued earlier on _rx_stream) guarantees
-                # GPU data is ready before this copy starts. Pinned dst enables true async DMA;
-                # pageable dst falls back to synchronous per CUDA spec (still correct, just slower).
-                cpu_ptr = self._rx_f16_cpu_buf.ctypes.data_as(ctypes.c_void_p)
-                self.cuda.memcpy_async(cpu_ptr, c_void_p(address), self._rx_buffer_size, 2, self._rx_stream)
-                self.cuda.stream_synchronize(self._rx_stream)
-                # kind=2 is DeviceToHost per cudaMemcpyKind enum
-                # Convert float16→float32 in-place into preallocated buffer (no per-frame temp alloc)
-                numpy.copyto(
-                    self._rx_f32_cpu_buf,
-                    self._rx_f16_cpu_buf.reshape(self._rx_height, self._rx_width, self._rx_num_comps),
-                    casting="same_kind",
-                )
-                import_buffer.copyNumpyArray(self._rx_f32_cpu_buf)
+                    mem_f16 = cp.cuda.UnownedMemory(address, f16_size, owner=None)
+                    memptr_f16 = cp.cuda.MemoryPointer(mem_f16, 0)
+                    cupy_f16 = cp.ndarray(
+                        (self._rx_height, self._rx_width, self._rx_num_comps),
+                        dtype=cp.float16,
+                        memptr=memptr_f16,
+                    )
+                    # Run conversion on _rx_stream so copyCUDAMemory (also on _rx_stream)
+                    # automatically serializes after the elementwise cast kernel.
+                    with cp.cuda.ExternalStream(rx_stream_int):
+                        cp.copyto(self._rx_cupy_f32_buf, cupy_f16, casting="same_kind")
+
+                    import_buffer.copyCUDAMemory(
+                        self._rx_cupy_f32_buf.data.ptr,
+                        f32_size,
+                        self._rx_cached_shape,  # dataType=float32 set during initialize_receiver()
+                        stream=rx_stream_int,
+                    )
+                else:
+                    # CPU fallback: D2H + numpy convert + copyNumpyArray.
+                    # Used when CuPy is not installed or GPU buffer allocation failed.
+                    if self._rx_f16_cpu_buf is None or self._rx_f32_cpu_buf is None:
+                        debug("[CUDAIPCLink] float16 CPU buffers not allocated — skipping frame")
+                        return False
+                    import ctypes
+                    from ctypes import c_void_p
+
+                    # D2H on _rx_stream: stream_wait_event (enqueued earlier) guarantees data is ready.
+                    cpu_ptr = self._rx_f16_cpu_buf.ctypes.data_as(ctypes.c_void_p)
+                    self.cuda.memcpy_async(cpu_ptr, c_void_p(address), self._rx_buffer_size, 2, self._rx_stream)
+                    self.cuda.stream_synchronize(self._rx_stream)
+                    numpy.copyto(
+                        self._rx_f32_cpu_buf,
+                        self._rx_f16_cpu_buf.reshape(self._rx_height, self._rx_width, self._rx_num_comps),
+                        casting="same_kind",
+                    )
+                    import_buffer.copyNumpyArray(self._rx_f32_cpu_buf)
             else:
                 import_buffer.copyCUDAMemory(
                     address,
@@ -1246,8 +1297,11 @@ class CUDAIPCExtension:
             with contextlib.suppress(AttributeError):
                 self.ownerComp.par.Numslots = self._rx_num_slots
 
+            # Cache receiver shutdown offset once — avoids per-frame arithmetic in import_frame()
+            self._rx_shutdown_offset = SHM_HEADER_SIZE + (self._rx_num_slots * SLOT_SIZE)
+
             # Read extended metadata (if available)
-            shutdown_offset = SHM_HEADER_SIZE + (self._rx_num_slots * SLOT_SIZE)
+            shutdown_offset = self._rx_shutdown_offset
             metadata_offset = shutdown_offset + SHUTDOWN_FLAG_SIZE
 
             # Check if SharedMemory is large enough for metadata
@@ -1434,6 +1488,22 @@ class CUDAIPCExtension:
                     (self._rx_height, self._rx_width, self._rx_num_comps), dtype=np_module.float32
                 )
 
+                # GPU-side float32 staging buffer for CuPy conversion path (avoids per-frame allocation).
+                # When CuPy is available, float16→float32 happens on GPU with zero PCIe traffic.
+                if CUPY_AVAILABLE:
+                    try:
+                        self._rx_cupy_f32_buf = cp.empty(
+                            (self._rx_height, self._rx_width, self._rx_num_comps), dtype=cp.float32
+                        )
+                        self._log(
+                            "float16 receiver: CuPy GPU float32 buffer allocated (GPU-side conversion path)", force=True
+                        )
+                    except Exception as _e:
+                        self._rx_cupy_f32_buf = None
+                        self._log(
+                            f"float16 receiver: CuPy GPU buffer alloc failed ({_e}), CPU fallback active", force=True
+                        )
+
             self._rx_cached_shape = CUDAMemoryShape()
             self._rx_cached_shape.width = self._rx_width
             self._rx_cached_shape.height = self._rx_height
@@ -1539,6 +1609,7 @@ class CUDAIPCExtension:
             self._rx_f16_pinned_ptr = None
         self._rx_f16_cpu_buf = None
         self._rx_f32_cpu_buf = None
+        self._rx_cupy_f32_buf = None  # CuPy memory pool handles GPU free on GC
         self._initialized = False
         self._rx_connect_attempts = 0
         self._rx_frames_since_last_retry = 0

--- a/td_exporter/CUDAIPCExtension.py
+++ b/td_exporter/CUDAIPCExtension.py
@@ -25,13 +25,9 @@ try:
 except ImportError:
     numpy = None  # Will be imported at runtime in TD
 
-try:
-    import cupy as cp
-
-    CUPY_AVAILABLE = True
-except ImportError:
-    cp = None
-    CUPY_AVAILABLE = False
+# Defer CuPy import to initialize_receiver() — heavy import imposes TD startup penalty
+CUPY_AVAILABLE: bool = False
+cp = None
 
 # Import types with fallbacks
 try:
@@ -42,7 +38,7 @@ except ImportError:
 
     CUDAMemoryShape = None  # Will be accessed as global in TD runtime
 
-from CUDAIPCWrapper import (
+from CUDAIPCWrapper import (  # noqa: E402
     cudaIpcEventHandle_t,
     cudaIpcMemHandle_t,
     get_cuda_runtime,
@@ -217,6 +213,7 @@ class CUDAIPCExtension:
         self._rx_f32_cpu_buf = None  # float32 CPU buffer after conversion (float16 IPC only)
         self._rx_f16_pinned_ptr = None  # cudaMallocHost pointer backing _rx_f16_cpu_buf (or None if pageable)
         self._rx_cupy_f32_buf = None  # float32 CuPy GPU buffer for GPU-side f16→f32 (CuPy path, float16 IPC only)
+        self._rx_cupy_f16_views: list = []  # per-slot float16 CuPy views (pre-allocated, avoids per-frame alloc)
 
         # Format conversion state — True when dtype_converter is set to rgba32float
         self._fmt_conv_active = False
@@ -614,7 +611,8 @@ class CUDAIPCExtension:
             True if export successful, False otherwise
         """
         top_op = self._export_buffer
-        if top_op is None:
+        if top_op is None or not getattr(top_op, "valid", True):
+            self._export_buffer = None  # invalidate stale cache
             # Lazy lookup: op may have been added after initialize() (e.g. dynamic network edits)
             top_op = self.ownerComp.op(_EXPORT_BUFFER_NAME)
             if top_op is None:
@@ -647,6 +645,9 @@ class CUDAIPCExtension:
             # Check source TOP (upstream of converter), not ExportBuffer (downstream).
             # Use cached reference (set in initialize()) to avoid per-frame ownerComp.op() lookup.
             fmt_transform = self._fmt_transform
+            if fmt_transform is not None and not getattr(fmt_transform, "valid", True):
+                self._fmt_transform = None
+                fmt_transform = None
             if fmt_transform is not None:
                 source_top = fmt_transform.inputs[0] if fmt_transform.inputs else top_op
                 if self._needs_format_conversion(source_top):
@@ -1168,13 +1169,7 @@ class CUDAIPCExtension:
                     f16_size = self._rx_buffer_size  # original float16 byte count
                     f32_size = f16_size * 2  # float32 = 2× bytes
 
-                    mem_f16 = cp.cuda.UnownedMemory(address, f16_size, owner=None)
-                    memptr_f16 = cp.cuda.MemoryPointer(mem_f16, 0)
-                    cupy_f16 = cp.ndarray(
-                        (self._rx_height, self._rx_width, self._rx_num_comps),
-                        dtype=cp.float16,
-                        memptr=memptr_f16,
-                    )
+                    cupy_f16 = self._rx_cupy_f16_views[read_slot]
                     # Run conversion on _rx_stream so copyCUDAMemory (also on _rx_stream)
                     # automatically serializes after the elementwise cast kernel.
                     with cp.cuda.ExternalStream(rx_stream_int):
@@ -1520,6 +1515,16 @@ class CUDAIPCExtension:
 
                 # GPU-side float32 staging buffer for CuPy conversion path (avoids per-frame allocation).
                 # When CuPy is available, float16→float32 happens on GPU with zero PCIe traffic.
+                # Lazy import: CuPy is heavy; defer until first receiver init to avoid TD startup penalty.
+                global CUPY_AVAILABLE, cp
+                if cp is None:
+                    try:
+                        import cupy as cp  # noqa: PLC0415
+
+                        CUPY_AVAILABLE = True
+                    except ImportError:
+                        CUPY_AVAILABLE = False
+
                 if CUPY_AVAILABLE:
                     try:
                         self._rx_cupy_f32_buf = cp.empty(
@@ -1528,8 +1533,22 @@ class CUDAIPCExtension:
                         self._log(
                             "float16 receiver: CuPy GPU float32 buffer allocated (GPU-side conversion path)", force=True
                         )
+                        # Pre-create per-slot float16 views to avoid per-frame UnownedMemory allocation.
+                        self._rx_cupy_f16_views = []
+                        for _i in range(self._rx_num_slots):
+                            _ptr = self._rx_dev_ptrs[_i].value
+                            _mem = cp.cuda.UnownedMemory(_ptr, self._rx_buffer_size, owner=self)
+                            _memptr = cp.cuda.MemoryPointer(_mem, 0)
+                            self._rx_cupy_f16_views.append(
+                                cp.ndarray(
+                                    (self._rx_height, self._rx_width, self._rx_num_comps),
+                                    dtype=cp.float16,
+                                    memptr=_memptr,
+                                )
+                            )
                     except Exception as _e:
                         self._rx_cupy_f32_buf = None
+                        self._rx_cupy_f16_views = []
                         self._log(
                             f"float16 receiver: CuPy GPU buffer alloc failed ({_e}), CPU fallback active", force=True
                         )
@@ -1640,6 +1659,7 @@ class CUDAIPCExtension:
         self._rx_f16_cpu_buf = None
         self._rx_f32_cpu_buf = None
         self._rx_cupy_f32_buf = None  # CuPy memory pool handles GPU free on GC
+        self._rx_cupy_f16_views = []
         self._initialized = False
         self._rx_connect_attempts = 0
         self._rx_frames_since_last_retry = 0

--- a/td_exporter/CUDAIPCExtension.py
+++ b/td_exporter/CUDAIPCExtension.py
@@ -220,6 +220,22 @@ class CUDAIPCExtension:
 
         # Format conversion state — True when dtype_converter is set to rgba32float
         self._fmt_conv_active = False
+        # Cached dtype_converter Transform TOP reference (stable; refreshed on initialize())
+        self._fmt_transform: object = None
+
+        # Lazy attributes — pre-initialized here to avoid per-frame hasattr()/getattr() fallbacks
+        self.ipc_stream = None  # Created on first export_frame() or initialize()
+        self._last_cuda_mem_err = ""  # Suppresses duplicate cudaMemory() error logs
+
+        # Dtype change detection — pre-initialized to eliminate per-frame hasattr() in _has_dtype_changed()
+        self._detected_numpy_dtype: object = None  # Set each frame from cuda_mem.shape.dataType
+        self._last_numpy_dtype: object = None  # Set in _write_metadata_to_shm()
+
+        # Cached parameter reference — eliminates 3-deep ownerComp.par.Active chain per frame
+        try:
+            self._active_par = ownerComp.par.Active
+        except AttributeError:
+            self._active_par = None  # Component has no Active parameter
 
         self._log(f"Extension initialized on {ownerComp} [Mode: {self._mode}]", force=True)
 
@@ -319,7 +335,7 @@ class CUDAIPCExtension:
 
             # Create dedicated non-blocking stream for IPC operations (fixes TD cudaMemory() perf warning)
             # Reuse existing stream on re-init to avoid leaks
-            if not hasattr(self, "ipc_stream") or self.ipc_stream is None:
+            if self.ipc_stream is None:
                 self.ipc_stream = self.cuda.create_stream(flags=0x01)  # cudaStreamNonBlocking
                 self._log(
                     f"Created IPC stream: 0x{int(self.ipc_stream.value):016x}",
@@ -398,6 +414,9 @@ class CUDAIPCExtension:
             # Cache SHM offsets: avoid recomputing these on every export_frame() call
             self._shutdown_offset = SHM_HEADER_SIZE + (self.num_slots * SLOT_SIZE)
             self._ts_offset = self._shutdown_offset + SHUTDOWN_FLAG_SIZE + METADATA_SIZE
+
+            # Cache dtype_converter TOP reference — eliminates per-frame ownerComp.op() lookup
+            self._fmt_transform = self.ownerComp.op(_FMT_TRANSFORM_NAME)
 
             # Create GPU timing events (only when Debug is ON for benchmarking)
             if self.verbose_performance:
@@ -500,7 +519,7 @@ class CUDAIPCExtension:
         metadata_offset = shutdown_offset + SHUTDOWN_FLAG_SIZE
 
         # Determine dtype_code from CUDAMemoryShape.dataType (preferred) or byte-ratio (fallback)
-        detected_dtype = getattr(self, "_detected_numpy_dtype", None)
+        detected_dtype = self._detected_numpy_dtype
         if detected_dtype is not None:
             try:
                 import numpy as _np
@@ -511,7 +530,7 @@ class CUDAIPCExtension:
                     _np.dtype("uint8"): DTYPE_UINT8,
                     _np.dtype("uint16"): DTYPE_UINT16,
                 }
-                dtype_code = _dtype_to_code.get(_np.dtype(detected_dtype), DTYPE_FLOAT32)
+                dtype_code = _dtype_to_code.get(detected_dtype, DTYPE_FLOAT32)
             except Exception:  # noqa: BLE001
                 detected_dtype = None  # Fall through to byte-ratio below
 
@@ -539,24 +558,22 @@ class CUDAIPCExtension:
         self.shm_handle.buf[metadata_offset + 16 : metadata_offset + 20] = struct.pack("<I", self.data_size)
 
         # Track last written dtype for change detection
-        self._last_numpy_dtype = getattr(self, "_detected_numpy_dtype", None)
+        self._last_numpy_dtype = self._detected_numpy_dtype
 
         self._log(
             f"Wrote metadata: {self.width}x{self.height}x{self.channels}, dtype={dtype_code}, size={self.data_size}B"
         )
 
     def _has_dtype_changed(self) -> bool:
-        """Check if detected numpy dtype differs from last written metadata."""
-        if self._detected_numpy_dtype is None:
-            return False  # Can't detect — assume unchanged
-        if not hasattr(self, "_last_numpy_dtype") or self._last_numpy_dtype is None:
-            return False  # First frame — will be set during initialize()
-        try:
-            import numpy as _np
+        """Check if detected numpy dtype differs from last written metadata.
 
-            return _np.dtype(self._detected_numpy_dtype) != _np.dtype(self._last_numpy_dtype)
-        except Exception:  # noqa: BLE001
-            return False
+        Both attributes are pre-initialized to None in __init__ and set as numpy.dtype
+        objects (from cuda_mem.shape.dataType / _write_metadata_to_shm), so direct
+        comparison is safe — no per-frame np.dtype() construction needed.
+        """
+        if self._detected_numpy_dtype is None or self._last_numpy_dtype is None:
+            return False  # Not yet detected or not yet written
+        return self._detected_numpy_dtype != self._last_numpy_dtype
 
     def _bump_version(self) -> None:
         """Increment SharedMemory version counter to signal consumers to re-read metadata."""
@@ -589,12 +606,9 @@ class CUDAIPCExtension:
             self._log(f"'{_EXPORT_BUFFER_NAME}' not found in component", force=True)
             return False
 
-        # Check if Active parameter is enabled
-        try:
-            if not bool(self.ownerComp.par.Active.eval()):
-                return False
-        except AttributeError:
-            pass  # No Active parameter, proceed with export
+        # Check if Active parameter is enabled (use cached par ref to avoid 3-deep chain per frame)
+        if self._active_par is not None and not bool(self._active_par.eval()):
+            return False
 
         # Start frame timer (only if verbose)
         if self.verbose_performance:
@@ -605,7 +619,7 @@ class CUDAIPCExtension:
             # Always use a non-blocking stream (never None/default stream) for TD 2025 compat.
             if self.cuda is None:
                 self.cuda = get_cuda_runtime()
-            if not hasattr(self, "ipc_stream") or self.ipc_stream is None:
+            if self.ipc_stream is None:
                 self.ipc_stream = self.cuda.create_stream(flags=0x01)  # cudaStreamNonBlocking
                 self._log(
                     f"Created IPC stream (pre-init): 0x{int(self.ipc_stream.value):016x}",
@@ -615,7 +629,8 @@ class CUDAIPCExtension:
             # TD 2025 rejects float16 pixel formats from cudaMemory().
             # dtype_converter Transform TOP sits before ExportBuffer — toggle its format param.
             # Check source TOP (upstream of converter), not ExportBuffer (downstream).
-            fmt_transform = self.ownerComp.op(_FMT_TRANSFORM_NAME)
+            # Use cached reference (set in initialize()) to avoid per-frame ownerComp.op() lookup.
+            fmt_transform = self._fmt_transform
             if fmt_transform is not None:
                 source_top = fmt_transform.inputs[0] if fmt_transform.inputs else top_op
                 if self._needs_format_conversion(source_top):
@@ -650,7 +665,7 @@ class CUDAIPCExtension:
             except Exception as cuda_err:
                 pixel_fmt = getattr(top_op, "pixelFormat", "unknown")
                 err_msg = f"cudaMemory() failed (pixelFormat={pixel_fmt}): {cuda_err}"
-                if err_msg != getattr(self, "_last_cuda_mem_err", ""):
+                if err_msg != self._last_cuda_mem_err:
                     self._log(err_msg, force=True)
                     self._last_cuda_mem_err = err_msg
                 return False
@@ -660,7 +675,7 @@ class CUDAIPCExtension:
                 self.total_cuda_memory_time += cuda_mem_time
 
             # Reset error suppression on success
-            if getattr(self, "_last_cuda_mem_err", ""):
+            if self._last_cuda_mem_err:
                 self._log("cudaMemory() recovered.", force=True)
                 self._last_cuda_mem_err = ""
 
@@ -671,13 +686,14 @@ class CUDAIPCExtension:
             # CRITICAL: Keep reference to prevent garbage collection
             self.cuda_mem_ref = cuda_mem
 
-            # Get dimensions from cuda_mem.shape
-            actual_width = cuda_mem.shape.width
-            actual_height = cuda_mem.shape.height
-            actual_channels = cuda_mem.shape.numComps
+            # Get dimensions from cuda_mem.shape (cache reference to avoid repeated lookups)
+            shape = cuda_mem.shape
+            actual_width = shape.width
+            actual_height = shape.height
+            actual_channels = shape.numComps
             actual_size = cuda_mem.size
             # CUDAMemoryShape.dataType returns numpy.dtype — more reliable than byte-ratio inference
-            self._detected_numpy_dtype = getattr(cuda_mem.shape, "dataType", None)
+            self._detected_numpy_dtype = getattr(shape, "dataType", None)
 
             # Check if we need to (re)initialize
             if not self._initialized or actual_size != self.data_size:
@@ -1057,12 +1073,9 @@ class CUDAIPCExtension:
         Returns:
             True if import successful, False otherwise.
         """
-        # Check Active parameter
-        try:
-            if not bool(self.ownerComp.par.Active.eval()):
-                return False
-        except AttributeError:
-            pass
+        # Check Active parameter (use cached par ref to avoid 3-deep chain per frame)
+        if self._active_par is not None and not bool(self._active_par.eval()):
+            return False
 
         # Lazy initialization with exponential backoff retry logic
         if not self._initialized:

--- a/td_exporter/CUDAIPCWrapper.py
+++ b/td_exporter/CUDAIPCWrapper.py
@@ -701,6 +701,48 @@ class CUDARuntimeAPI:
         self.check_error(result, "cudaMemGetInfo")
         return free.value, total.value
 
+    def stream_query(self, stream: CUDAStream_t) -> bool:
+        """Non-blocking check if all operations on stream have completed.
+
+        Args:
+            stream: CUDA stream to query
+
+        Returns:
+            True if all stream operations have completed, False if still executing
+
+        Raises:
+            RuntimeError: If query fails with an error other than cudaErrorNotReady
+        """
+        result = self.cudart.cudaStreamQuery(stream)
+        if result == 0:  # cudaSuccess
+            return True
+        if result == 600:  # cudaErrorNotReady
+            return False
+        self.check_error(result, "cudaStreamQuery")
+        return False  # unreachable
+
+    def device_can_access_peer(self, device: int, peer_device: int) -> bool:
+        """Check if device can directly access peer_device memory via IPC/NVLink.
+
+        Useful for validating multi-GPU setups before attempting IPC handle operations.
+        On single-GPU systems or systems without peer access, cudaIpcOpenMemHandle
+        may fall back to slower paths without warning.
+
+        Args:
+            device: Source device ID
+            peer_device: Target peer device ID
+
+        Returns:
+            True if direct peer access is available, False otherwise
+
+        Raises:
+            RuntimeError: If query fails
+        """
+        can_access = c_int(0)
+        result = self.cudart.cudaDeviceCanAccessPeer(byref(can_access), device, peer_device)
+        self.check_error(result, "cudaDeviceCanAccessPeer")
+        return bool(can_access.value)
+
 
 # Global singleton instance (lazy initialization)
 _cuda_runtime: CUDARuntimeAPI | None = None

--- a/td_exporter/CUDAIPCWrapper.py
+++ b/td_exporter/CUDAIPCWrapper.py
@@ -288,6 +288,14 @@ class CUDARuntimeAPI:
         self.cudart.cudaGetDevice.argtypes = [POINTER(c_int)]
         self.cudart.cudaGetDevice.restype = c_int
 
+        # cudaStreamQuery(cudaStream_t stream)
+        self.cudart.cudaStreamQuery.argtypes = [CUDAStream_t]
+        self.cudart.cudaStreamQuery.restype = c_int
+
+        # cudaDeviceCanAccessPeer(int* canAccessPeer, int device, int peerDevice)
+        self.cudart.cudaDeviceCanAccessPeer.argtypes = [POINTER(c_int), c_int, c_int]
+        self.cudart.cudaDeviceCanAccessPeer.restype = c_int
+
     def check_error(self, result: int, operation: str) -> None:
         """Check CUDA error code and raise exception if failed.
 

--- a/td_exporter/CUDAIPCWrapper.py
+++ b/td_exporter/CUDAIPCWrapper.py
@@ -54,6 +54,7 @@ class CUDAError:
     INVALID_DEVICE_POINTER = 17
     INVALID_DEVICE = 101
     INVALID_CONTEXT = 201  # Common in same-process IPC testing
+    NOT_READY = 600
     PEER_ACCESS_ALREADY_ENABLED = 704
 
     @staticmethod
@@ -66,6 +67,7 @@ class CUDAError:
             17: "INVALID_DEVICE_POINTER",
             101: "INVALID_DEVICE",
             201: "INVALID_CONTEXT",
+            600: "NOT_READY",
             704: "PEER_ACCESS_ALREADY_ENABLED",
         }
         return names.get(code, f"UNKNOWN_ERROR_{code}")
@@ -497,7 +499,7 @@ class CUDARuntimeAPI:
         result = self.cudart.cudaEventQuery(event)
         if result == CUDAError.SUCCESS:
             return True
-        elif result == 600:  # cudaErrorNotReady
+        elif result == CUDAError.NOT_READY:
             return False
         self.check_error(result, "cudaEventQuery")
         return False
@@ -722,9 +724,9 @@ class CUDARuntimeAPI:
             RuntimeError: If query fails with an error other than cudaErrorNotReady
         """
         result = self.cudart.cudaStreamQuery(stream)
-        if result == 0:  # cudaSuccess
+        if result == CUDAError.SUCCESS:
             return True
-        if result == 600:  # cudaErrorNotReady
+        if result == CUDAError.NOT_READY:
             return False
         self.check_error(result, "cudaStreamQuery")
         return False  # unreachable

--- a/tests/test_cuda_ipc_exporter.py
+++ b/tests/test_cuda_ipc_exporter.py
@@ -377,6 +377,7 @@ def _make_receiver_with_float16_state(use_cupy: bool = False) -> object:
     ext = object.__new__(CUDAIPCExtension)
     ext.ownerComp = MagicMock()
     ext.ownerComp.par.Active.eval.return_value = True
+    ext._active_par = ext.ownerComp.par.Active  # cached par ref (set in __init__)
     ext.verbose_performance = False
     ext._initialized = True
     ext._mode = "Receiver"

--- a/tests/test_cuda_ipc_exporter.py
+++ b/tests/test_cuda_ipc_exporter.py
@@ -411,10 +411,13 @@ def _make_receiver_with_float16_state(use_cupy: bool = False) -> object:
     ext.shm_handle.buf = buf
 
     # CuPy GPU buffer (only if CuPy path is being tested)
+    from unittest.mock import MagicMock as _MagicMock
     if use_cupy:
         ext._rx_cupy_f32_buf = np.zeros((HEIGHT, WIDTH, COMPS), dtype=np.float32)
+        ext._rx_cupy_f16_views = [_MagicMock() for _ in range(NUM_SLOTS)]
     else:
         ext._rx_cupy_f32_buf = None
+        ext._rx_cupy_f16_views = []
 
     ext._rx_frames_since_last_retry = 0
     ext._rx_connect_attempts = 0

--- a/tests/test_cuda_ipc_exporter.py
+++ b/tests/test_cuda_ipc_exporter.py
@@ -341,3 +341,128 @@ def test_log_helper() -> None:
     # Enable verbosity
     exporter.verbose_performance = True
     exporter._log("Verbose message")
+
+
+# ---------------------------------------------------------------------------
+# Improvement 4: GPU-side float16→float32 conversion in TD receiver
+# ---------------------------------------------------------------------------
+
+
+def _make_receiver_with_float16_state(use_cupy: bool = False) -> object:
+    """Build a CUDAIPCExtension (Receiver) with manually-injected float16 state.
+
+    Bypasses real CUDA/CuPy initialization to test routing logic only.
+    """
+    import struct
+    from unittest.mock import MagicMock, patch
+
+    import numpy as np
+
+    # Patch Mode parameter before construction so __init__ thinks it's Receiver
+    with patch("CUDAIPCExtension.CUPY_AVAILABLE", use_cupy):
+        from CUDAIPCExtension import DTYPE_FLOAT16, SHM_HEADER_SIZE, SLOT_SIZE, CUDAIPCExtension
+
+    HEIGHT, WIDTH, COMPS = 4, 4, 4
+    NUM_SLOTS = 2
+    F16_SIZE = HEIGHT * WIDTH * COMPS * 2  # float16 = 2 bytes/elem
+
+    # Build a bytearray that looks like valid SHM (write_idx=1)
+    shm_size = SHM_HEADER_SIZE + NUM_SLOTS * SLOT_SIZE + 1 + 20 + 8
+    buf = bytearray(shm_size)
+    struct.pack_into("<I", buf, 0, 0x43495043)  # magic
+    struct.pack_into("<Q", buf, 4, 1)  # version
+    struct.pack_into("<I", buf, 12, NUM_SLOTS)  # num_slots
+    struct.pack_into("<I", buf, 16, 1)  # write_idx=1
+
+    ext = object.__new__(CUDAIPCExtension)
+    ext.ownerComp = MagicMock()
+    ext.ownerComp.par.Active.eval.return_value = True
+    ext.verbose_performance = False
+    ext._initialized = True
+    ext._mode = "Receiver"
+    ext.frame_count = 0
+    ext._rx_last_write_idx = 0
+    ext._rx_ipc_version = 1
+    ext._rx_num_slots = NUM_SLOTS
+    ext._rx_shutdown_offset = SHM_HEADER_SIZE + (NUM_SLOTS * SLOT_SIZE)
+    ext._rx_width = WIDTH
+    ext._rx_height = HEIGHT
+    ext._rx_num_comps = COMPS
+    ext._rx_dtype_code = DTYPE_FLOAT16
+    ext._rx_buffer_size = F16_SIZE
+    ext._rx_dev_ptrs = [MagicMock() for _ in range(NUM_SLOTS)]
+    ext._rx_dev_ptrs[0].value = 0xDEAD0000  # fake GPU ptr for slot 0
+    ext._rx_ipc_events = [MagicMock(), MagicMock()]
+    ext._rx_stream = MagicMock()
+    ext._rx_stream.value = 0x1234
+
+    # CPU fallback buffers (always allocated even in CuPy path — used as fallback)
+    ext._rx_f16_cpu_buf = np.zeros(HEIGHT * WIDTH * COMPS, dtype=np.float16)
+    ext._rx_f32_cpu_buf = np.zeros((HEIGHT, WIDTH, COMPS), dtype=np.float32)
+    ext._rx_f16_pinned_ptr = None
+
+    # CUDAMemoryShape mock (shape for copyCUDAMemory)
+    mock_shape = MagicMock()
+    ext._rx_cached_shape = mock_shape
+
+    ext.cuda = MagicMock()
+    ext.shm_handle = MagicMock()
+    ext.shm_handle.buf = buf
+
+    # CuPy GPU buffer (only if CuPy path is being tested)
+    if use_cupy:
+        ext._rx_cupy_f32_buf = np.zeros((HEIGHT, WIDTH, COMPS), dtype=np.float32)
+    else:
+        ext._rx_cupy_f32_buf = None
+
+    ext._rx_frames_since_last_retry = 0
+    ext._rx_connect_attempts = 0
+
+    return ext
+
+
+def test_float16_receiver_uses_cpu_fallback_when_cupy_unavailable() -> None:
+    """import_frame() uses copyNumpyArray (CPU path) when CuPy is not available."""
+    from unittest.mock import MagicMock, patch
+
+    ext = _make_receiver_with_float16_state(use_cupy=False)
+
+    import_buffer = MagicMock()
+
+    with patch("CUDAIPCExtension.CUPY_AVAILABLE", False):
+        result = ext.import_frame(import_buffer)
+
+    assert result is True
+    import_buffer.copyNumpyArray.assert_called_once()
+    import_buffer.copyCUDAMemory.assert_not_called()
+
+
+def test_float16_receiver_uses_gpu_path_when_cupy_available() -> None:
+    """import_frame() uses copyCUDAMemory (GPU path) when CuPy is available.
+
+    The GPU path eliminates both PCIe roundtrips: instead of GPU→CPU→GPU it
+    performs f16→f32 conversion entirely on-device via CuPy's copyto, then
+    calls copyCUDAMemory with the resulting float32 GPU pointer.
+    """
+    from unittest.mock import MagicMock, patch
+
+    ext = _make_receiver_with_float16_state(use_cupy=True)
+
+    import_buffer = MagicMock()
+
+    # Build a minimal CuPy mock: UnownedMemory, MemoryPointer, ndarray, ExternalStream, copyto
+    mock_cp = MagicMock()
+    mock_cp.float16 = "float16"
+    mock_cp.float32 = "float32"
+    # .data.ptr on the f32 buf must return an integer (GPU pointer)
+    ext._rx_cupy_f32_buf = MagicMock()
+    ext._rx_cupy_f32_buf.data.ptr = 0xF3200000
+
+    with patch("CUDAIPCExtension.CUPY_AVAILABLE", True), patch("CUDAIPCExtension.cp", mock_cp):
+        result = ext.import_frame(import_buffer)
+
+    assert result is True
+    import_buffer.copyCUDAMemory.assert_called_once()
+    import_buffer.copyNumpyArray.assert_not_called()
+    # ExternalStream context manager must be used
+    mock_cp.cuda.ExternalStream.assert_called_once()

--- a/tests/test_cuda_ipc_exporter_python.py
+++ b/tests/test_cuda_ipc_exporter_python.py
@@ -355,3 +355,142 @@ def test_timestamp_uses_perf_counter(temp_shm_name: str, shared_memory_cleanup: 
             shm.close()
     finally:
         exp.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Improvement 2: SharedMemory write ordering (atomicity)
+# ---------------------------------------------------------------------------
+
+
+def _make_exporter_with_mock_state(num_slots: int = 2, dtype: str = "uint8") -> object:
+    """Build a CUDAIPCExporter with manually-injected state (no real CUDA required).
+
+    Tests that verify SharedMemory write ordering inject all state via MagicMock and a
+    bytearray buffer, bypassing real CUDA IPC initialization entirely.
+    """
+    from unittest.mock import MagicMock
+
+    from cuda_link.cuda_ipc_exporter import (
+        METADATA_SIZE,
+        SHM_HEADER_SIZE,
+        SHUTDOWN_FLAG_SIZE,
+        SLOT_SIZE,
+        TIMESTAMP_SIZE,
+        CUDAIPCExporter,
+    )
+
+    shm_size = SHM_HEADER_SIZE + num_slots * SLOT_SIZE + SHUTDOWN_FLAG_SIZE + METADATA_SIZE + TIMESTAMP_SIZE
+
+    exp = object.__new__(CUDAIPCExporter)
+    exp.shm_name = "mock_shm"
+    exp.height = 8
+    exp.width = 8
+    exp.channels = 4
+    exp.dtype = dtype
+    exp.num_slots = num_slots
+    exp.debug = False
+    exp.data_size = 8 * 8 * 4  # H * W * C * itemsize (uint8 = 1 byte)
+    exp.write_idx = 0
+    exp.frame_count = 0
+    exp.source_sync_event = None
+    exp.ipc_stream = MagicMock()
+    exp.cuda = MagicMock()
+    exp.dev_ptrs = [MagicMock() for _ in range(num_slots)]
+    exp.ipc_events = [None] * num_slots
+    exp._shutdown_offset = SHM_HEADER_SIZE + num_slots * SLOT_SIZE
+    exp._ts_offset = exp._shutdown_offset + SHUTDOWN_FLAG_SIZE + METADATA_SIZE
+    exp._initialized = True
+
+    exp.shm_handle = MagicMock()
+    exp.shm_handle.buf = bytearray(shm_size)
+
+    return exp
+
+
+def test_shm_write_correctness_after_export_frame() -> None:
+    """After export_frame(), shutdown_flag=0 and write_idx is incremented by 1."""
+    exp = _make_exporter_with_mock_state()
+    buf = exp.shm_handle.buf
+
+    # Simulate stale shutdown_flag=1 left by a prior producer session
+    buf[exp._shutdown_offset] = 1
+    initial_write_idx = exp.write_idx
+
+    result = exp.export_frame(gpu_ptr=0, size=exp.data_size)
+
+    assert result is True
+    assert buf[exp._shutdown_offset] == 0, "shutdown_flag must be 0 after export_frame()"
+    actual_write_idx = struct.unpack_from("<I", buf, 16)[0]
+    assert actual_write_idx == initial_write_idx + 1, (
+        f"write_idx must increment from {initial_write_idx} to {initial_write_idx + 1}, got {actual_write_idx}"
+    )
+
+
+def test_shm_write_ordering_shutdown_before_write_idx() -> None:
+    """shutdown_flag is cleared BEFORE write_idx is published.
+
+    Atomicity invariant: the consumer reads shutdown_flag BEFORE write_idx.
+    Publishing write_idx last ensures the consumer always sees shutdown_flag=0
+    when it detects a new frame, even with a stale flag=1 from a prior session.
+    """
+    import struct as real_struct
+    from unittest.mock import MagicMock, patch
+
+    write_log: list[tuple] = []
+
+    class _SpyBuf(bytearray):
+        """bytearray subclass that records __setitem__ writes in write_log."""
+
+        def __setitem__(self, key, val) -> None:
+            if isinstance(key, int):
+                write_log.append(("setitem", key, val))
+            super().__setitem__(key, val)
+
+    # Spy on _ST_U32.pack_into (write_idx publish uses this pre-compiled Struct)
+    real_st_u32 = real_struct.Struct("<I")
+    real_st_f64 = real_struct.Struct("<d")
+
+    def spy_u32_pack_into(buf, offset: int, *args) -> None:
+        write_log.append(("pack_into", offset))
+        real_st_u32.pack_into(buf, offset, *args)
+
+    def spy_f64_pack_into(buf, offset: int, *args) -> None:
+        real_st_f64.pack_into(buf, offset, *args)
+
+    mock_st_u32 = MagicMock()
+    mock_st_u32.pack_into.side_effect = spy_u32_pack_into
+    mock_st_f64 = MagicMock()
+    mock_st_f64.pack_into.side_effect = spy_f64_pack_into
+
+    exp = _make_exporter_with_mock_state()
+
+    # Replace the plain bytearray with our spy; set stale shutdown_flag=1
+    spy_buf = _SpyBuf(len(exp.shm_handle.buf))
+    spy_buf[exp._shutdown_offset] = 1
+    write_log.clear()  # discard the setup write above
+    exp.shm_handle.buf = spy_buf
+
+    with (
+        patch("cuda_link.cuda_ipc_exporter._ST_U32", mock_st_u32),
+        patch("cuda_link.cuda_ipc_exporter._ST_F64", mock_st_f64),
+    ):
+        result = exp.export_frame(gpu_ptr=0, size=exp.data_size)
+
+    assert result is True
+
+    WRITE_IDX_OFFSET = 16
+    shutdown_pos = next(
+        (i for i, e in enumerate(write_log) if e[0] == "setitem" and e[1] == exp._shutdown_offset),
+        None,
+    )
+    write_idx_pos = next(
+        (i for i, e in enumerate(write_log) if e[0] == "pack_into" and e[1] == WRITE_IDX_OFFSET),
+        None,
+    )
+
+    assert shutdown_pos is not None, "shutdown_flag must be written during export_frame()"
+    assert write_idx_pos is not None, "write_idx must be published during export_frame()"
+    assert shutdown_pos < write_idx_pos, (
+        f"shutdown_flag write (log[{shutdown_pos}]) must precede "
+        f"write_idx publish (log[{write_idx_pos}]); full log: {write_log}"
+    )

--- a/tests/test_cuda_ipc_importer.py
+++ b/tests/test_cuda_ipc_importer.py
@@ -281,7 +281,6 @@ def _make_importer_with_mock_state(shape: tuple, dtype: str, num_slots: int = 1)
     return imp
 
 
-@pytest.mark.requires_cuda
 def test_get_frame_numpy_always_uses_cpu_poll() -> None:
     """get_frame_numpy() always uses _wait_for_slot (CPU poll) for the normal D2H path.
 

--- a/tests/test_cuda_ipc_importer.py
+++ b/tests/test_cuda_ipc_importer.py
@@ -208,6 +208,108 @@ def test_shutdown_detection(cuda_runtime: object, temp_shm_name: str, shared_mem
         shm.close()
 
 
+# ---------------------------------------------------------------------------
+# Improvement 1: Stream-ordered wait in get_frame_numpy()
+# ---------------------------------------------------------------------------
+
+
+def _make_importer_with_mock_state(shape: tuple, dtype: str, num_slots: int = 1) -> object:
+    """Build a CUDAIPCImporter with manually-injected state (no real CUDA IPC handles).
+
+    CUDA IPC handles cannot be opened in the same process that created them, so tests
+    that check routing logic inject all state via MagicMock and a bytearray SHM buffer.
+    """
+    from unittest.mock import MagicMock
+
+    import numpy as np
+
+    from cuda_link.cuda_ipc_importer import (
+        METADATA_SIZE,
+        SHM_HEADER_SIZE,
+        SHUTDOWN_FLAG_SIZE,
+        SLOT_SIZE,
+        TIMESTAMP_SIZE,
+        CUDAIPCImporter,
+    )
+
+    # Build a bytearray that looks like valid SharedMemory (write_idx=1 → one frame ready)
+    shm_size = SHM_HEADER_SIZE + num_slots * SLOT_SIZE + SHUTDOWN_FLAG_SIZE + METADATA_SIZE + TIMESTAMP_SIZE
+    buf = bytearray(shm_size)
+    struct.pack_into("<I", buf, 0, 0x43495043)  # magic "CIPC"
+    struct.pack_into("<Q", buf, 4, 1)  # version=1
+    struct.pack_into("<I", buf, 12, num_slots)  # num_slots
+    struct.pack_into("<I", buf, 16, 1)  # write_idx=1
+
+    # Bypass __init__ entirely, inject all attributes manually
+    imp = object.__new__(CUDAIPCImporter)
+    imp.shm_name = "mock_shm"
+    imp.shape = shape
+    imp.dtype = dtype
+    imp.debug = False
+    imp.timeout_ms = 5000.0
+    imp.num_slots = num_slots
+    imp.ipc_handles = [None] * num_slots
+    imp.dev_ptrs = [MagicMock() for _ in range(num_slots)]
+    imp.ipc_events = [None] * num_slots
+    imp.tensors = [None] * num_slots
+    imp._wrappers = [None] * num_slots
+    imp.cupy_arrays = [None] * num_slots
+    imp.frame_count = 0
+    imp._last_write_idx = 0
+    imp.total_wait_event_time = 0.0
+    imp.total_get_frame_time = 0.0
+    imp.total_shm_read_us = 0.0
+    imp.last_latency = 0.0
+    imp.ipc_version = 1  # matches version=1 written into buf above
+    imp._shutdown_offset = SHM_HEADER_SIZE + num_slots * SLOT_SIZE
+    imp._timestamp_offset = imp._shutdown_offset + SHUTDOWN_FLAG_SIZE + METADATA_SIZE
+    imp._initialized = True
+
+    # Inject mock CUDA runtime and numpy stream
+    imp.cuda = MagicMock()
+    imp._numpy_stream = MagicMock()
+
+    # Inject mock SharedMemory whose .buf is our bytearray
+    imp.shm_handle = MagicMock()
+    imp.shm_handle.buf = buf
+
+    # Pre-allocate real numpy buffer so get_frame_numpy() skips reallocation and
+    # memcpy_async receives a valid ctypes pointer
+    imp._numpy_buffer = np.zeros(shape, dtype=np.dtype(dtype))
+    imp._pinned_ptr = None
+
+    return imp
+
+
+@pytest.mark.requires_cuda
+def test_get_frame_numpy_always_uses_cpu_poll() -> None:
+    """get_frame_numpy() always uses _wait_for_slot (CPU poll) for the normal D2H path.
+
+    cudaStreamWaitEvent on cross-process IPC events has high kernel-mode IPC latency
+    on Windows (~100-300ms). The CPU poll path (query_event loop) is used unconditionally
+    because improvement #2 guarantees the event is already signaled when write_idx is read.
+    """
+    from unittest.mock import patch
+
+    for has_event in (False, True):
+        imp = _make_importer_with_mock_state(shape=(8, 8, 4), dtype="float32")
+        sentinel_event = object() if has_event else None
+        imp.ipc_events[0] = sentinel_event
+
+        poll_calls: list[int] = []
+        stream_wait_calls: list[tuple] = []
+
+        with (
+            patch.object(imp, "_wait_for_slot", side_effect=lambda s: poll_calls.append(s) or 0.0),  # noqa: B023
+            patch.object(imp.cuda, "stream_wait_event", side_effect=lambda *a: stream_wait_calls.append(a)),  # noqa: B023
+        ):
+            imp.get_frame_numpy()
+
+        assert len(poll_calls) == 1, f"has_event={has_event}: _wait_for_slot must always be called"
+        assert poll_calls[0] == 0, "Must wait on slot 0"
+        assert len(stream_wait_calls) == 0, f"has_event={has_event}: stream_wait_event must NOT be called in numpy path"
+
+
 @pytest.mark.requires_cuda
 def test_read_slot_calculation() -> None:
     """Test _get_read_slot() logic."""


### PR DESCRIPTION
## Summary

Follow-up audit of the OPT-2–OPT-11 batch revealed 7 additional findings (1 HIGH, 3 MEDIUM, 1 BUG, 2 LOW), all verified against source. This PR addresses the complete set as a single batch.

**Stacked on**: #8 (OPT-2 to OPT-11 batch). Merge that first, then this rebases to `master`.

---

## Findings Fixed

### F1 — HIGH: Cache `ownerComp.op(ExportBuffer)` reference (~5-20µs/frame)
`ownerComp.op(_EXPORT_BUFFER_NAME)` was called every frame at line 604 — identical anti-pattern to OPT-9 which cached `_fmt_transform`. Applied the same `__init__` → `initialize()` → use-from-cache pattern with a lazy fallback for ops added after init.

### F2 — MEDIUM: Cache `_needs_format_conversion()` result (~200-500ns/frame)
`getattr().lower()` + substring-scan set on every frame. Now caches the last pixel format string and short-circuits when format is unchanged (99%+ of frames).

### F3 — MEDIUM: Direct `shape.dataType` access (~50-100ns/frame)
`getattr(shape, "dataType", None)` replaced with direct attribute access + `try/except AttributeError`. Siblings (`shape.width`, `shape.height`, `shape.numComps`) already used direct access.

### F4 — MEDIUM: Eliminate dict literal in `_dtype_itemsize()`, cache `_numpy_dtype()` (~300-500ns/frame)
`_DTYPE_SIZES` hoisted to module-level constant. `_numpy_dtype()` caches the `np.dtype()` result per dtype string with auto-invalidation when `self.dtype` changes.

### F5 — BUG: Missing `argtypes` for `cudaStreamQuery` and `cudaDeviceCanAccessPeer`
Both functions were absent from `_setup_function_signatures()` in both wrapper files. Without `argtypes`, passing a raw Python `int` as `CUDAStream_t` (c_uint64) silently truncates to 32-bit on 64-bit systems. Fixed in both `cuda_ipc_wrapper.py` and `CUDAIPCWrapper.py` (kept in sync).

### F6 — LOW: Hoist `CUDAStream_t` import in exporter (~200-500ns/frame)
`from .cuda_ipc_wrapper import CUDAStream_t` was inline inside per-frame `record_source_sync()`. Hoisted to module-level import.

### F7 — LOW: Remove redundant inline imports in `CUDAIPCExtension`
`import ctypes` + duplicate `from ctypes import c_void_p` in the float16 CPU fallback path. `c_void_p` was already imported at module level (line 20). Also removed redundant `SharedMemory` re-import in `_cleanup_sender()`.

---

## Files Changed

| File | Findings |
|------|---------|
| `td_exporter/CUDAIPCExtension.py` | F1, F2, F3, F7 |
| `src/cuda_link/cuda_ipc_wrapper.py` | F5 |
| `td_exporter/CUDAIPCWrapper.py` | F5 (kept in sync) |
| `src/cuda_link/cuda_ipc_importer.py` | F4 |
| `src/cuda_link/cuda_ipc_exporter.py` | F6 |

## Test plan

- [ ] All 85 tests pass: `pytest tests/ -v`
- [ ] Wrapper sync test passes: `test_wrapper_files_are_identical`
- [ ] No regressions in `benchmark_roundtrip.py` at 512×512 and 1080p
- [ ] Grep validation: no `ownerComp.op()` in per-frame `export_frame()` body; no inline imports in per-frame paths

🤖 Generated with [Claude Code](https://claude.ai/claude-code)