### PR TITLE
fix: close resource leaks and harden error handling in td_exporter (audit #2-#5)

### DIFF
--- a/src/cuda_link/cuda_runtime_types.py
+++ b/src/cuda_link/cuda_runtime_types.py
@@ -105,25 +105,25 @@ class cudaPointerAttributes(ctypes.Structure):
     ]
 
 
-assert ctypes.sizeof(cudaIpcMemHandle_t) == 64, (
-    f"cudaIpcMemHandle_t ABI mismatch: expected 64 bytes, got {ctypes.sizeof(cudaIpcMemHandle_t)}"
-)
-assert ctypes.sizeof(cudaIpcEventHandle_t) == 64, (
-    f"cudaIpcEventHandle_t ABI mismatch: expected 64 bytes, got {ctypes.sizeof(cudaIpcEventHandle_t)}"
-)
-assert ctypes.sizeof(cudaPointerAttributes) == 24, (
-    f"cudaPointerAttributes ABI mismatch: expected 24 bytes, got {ctypes.sizeof(cudaPointerAttributes)}"
-)
+def _abi_guard(actual: int, expected: int, name: str) -> None:
+    """Raise RuntimeError on ctypes struct size drift.
+
+    Deliberately NOT an `assert` — asserts are stripped under `python -O`, which would
+    let a struct layout mismatch pass silently instead of failing loudly at import time.
+    """
+    if actual != expected:
+        raise RuntimeError(f"{name} ABI mismatch: expected {expected} bytes, got {actual}")
+
+
+_abi_guard(ctypes.sizeof(cudaIpcMemHandle_t), 64, "cudaIpcMemHandle_t")
+_abi_guard(ctypes.sizeof(cudaIpcEventHandle_t), 64, "cudaIpcEventHandle_t")
+_abi_guard(ctypes.sizeof(cudaPointerAttributes), 24, "cudaPointerAttributes")
 # Graph param struct ABI guards — cudaMemcpy3DParms is the largest and most alignment-sensitive.
 # All four values were verified against Python ctypes on a 64-bit Windows host (sizeof c_size_t=8).
-assert ctypes.sizeof(cudaPos) == 24, f"cudaPos ABI mismatch: expected 24 bytes, got {ctypes.sizeof(cudaPos)}"
-assert ctypes.sizeof(cudaPitchedPtr) == 32, (
-    f"cudaPitchedPtr ABI mismatch: expected 32 bytes, got {ctypes.sizeof(cudaPitchedPtr)}"
-)
-assert ctypes.sizeof(cudaExtent) == 24, f"cudaExtent ABI mismatch: expected 24 bytes, got {ctypes.sizeof(cudaExtent)}"
-assert ctypes.sizeof(cudaMemcpy3DParms) == 160, (
-    f"cudaMemcpy3DParms ABI mismatch: expected 160 bytes, got {ctypes.sizeof(cudaMemcpy3DParms)}"
-)
+_abi_guard(ctypes.sizeof(cudaPos), 24, "cudaPos")
+_abi_guard(ctypes.sizeof(cudaPitchedPtr), 32, "cudaPitchedPtr")
+_abi_guard(ctypes.sizeof(cudaExtent), 24, "cudaExtent")
+_abi_guard(ctypes.sizeof(cudaMemcpy3DParms), 160, "cudaMemcpy3DParms")
 
 
 # CUDA Error codes (subset)

--- a/src/cuda_link/nvml_observer.py
+++ b/src/cuda_link/nvml_observer.py
@@ -147,8 +147,10 @@ class NVMLObserver:
             return False
         if self._started:
             return True
+        acquired = False
         try:
             _NVML_REFS.acquire()
+            acquired = True
             self._handle = pynvml.nvmlDeviceGetHandleByIndex(self.device)
             with contextlib.suppress(pynvml.NVMLError):
                 # Raises NVMLError_NotSupported on Linux (driver-model is Windows-only).
@@ -163,6 +165,11 @@ class NVMLObserver:
             self._started = True
             return True
         except (pynvml.NVMLError, RuntimeError, OSError) as e:
+            # Only release a ref we actually acquired — if nvmlInit() itself (inside
+            # acquire()) was what failed, release() would wrongly nvmlShutdown() an
+            # NVML that was never successfully initialized by this call.
+            if acquired:
+                _NVML_REFS.release()
             logger.warning("NVML start failed for device %d: %s", self.device, e)
             return False
 

--- a/td_exporter/CUDARuntimeTypes.py
+++ b/td_exporter/CUDARuntimeTypes.py
@@ -105,25 +105,25 @@ class cudaPointerAttributes(ctypes.Structure):
     ]
 
 
-assert ctypes.sizeof(cudaIpcMemHandle_t) == 64, (
-    f"cudaIpcMemHandle_t ABI mismatch: expected 64 bytes, got {ctypes.sizeof(cudaIpcMemHandle_t)}"
-)
-assert ctypes.sizeof(cudaIpcEventHandle_t) == 64, (
-    f"cudaIpcEventHandle_t ABI mismatch: expected 64 bytes, got {ctypes.sizeof(cudaIpcEventHandle_t)}"
-)
-assert ctypes.sizeof(cudaPointerAttributes) == 24, (
-    f"cudaPointerAttributes ABI mismatch: expected 24 bytes, got {ctypes.sizeof(cudaPointerAttributes)}"
-)
+def _abi_guard(actual: int, expected: int, name: str) -> None:
+    """Raise RuntimeError on ctypes struct size drift.
+
+    Deliberately NOT an `assert` — asserts are stripped under `python -O`, which would
+    let a struct layout mismatch pass silently instead of failing loudly at import time.
+    """
+    if actual != expected:
+        raise RuntimeError(f"{name} ABI mismatch: expected {expected} bytes, got {actual}")
+
+
+_abi_guard(ctypes.sizeof(cudaIpcMemHandle_t), 64, "cudaIpcMemHandle_t")
+_abi_guard(ctypes.sizeof(cudaIpcEventHandle_t), 64, "cudaIpcEventHandle_t")
+_abi_guard(ctypes.sizeof(cudaPointerAttributes), 24, "cudaPointerAttributes")
 # Graph param struct ABI guards — cudaMemcpy3DParms is the largest and most alignment-sensitive.
 # All four values were verified against Python ctypes on a 64-bit Windows host (sizeof c_size_t=8).
-assert ctypes.sizeof(cudaPos) == 24, f"cudaPos ABI mismatch: expected 24 bytes, got {ctypes.sizeof(cudaPos)}"
-assert ctypes.sizeof(cudaPitchedPtr) == 32, (
-    f"cudaPitchedPtr ABI mismatch: expected 32 bytes, got {ctypes.sizeof(cudaPitchedPtr)}"
-)
-assert ctypes.sizeof(cudaExtent) == 24, f"cudaExtent ABI mismatch: expected 24 bytes, got {ctypes.sizeof(cudaExtent)}"
-assert ctypes.sizeof(cudaMemcpy3DParms) == 160, (
-    f"cudaMemcpy3DParms ABI mismatch: expected 160 bytes, got {ctypes.sizeof(cudaMemcpy3DParms)}"
-)
+_abi_guard(ctypes.sizeof(cudaPos), 24, "cudaPos")
+_abi_guard(ctypes.sizeof(cudaPitchedPtr), 32, "cudaPitchedPtr")
+_abi_guard(ctypes.sizeof(cudaExtent), 24, "cudaExtent")
+_abi_guard(ctypes.sizeof(cudaMemcpy3DParms), 160, "cudaMemcpy3DParms")
 
 
 # CUDA Error codes (subset)

--- a/td_exporter/NVMLObserver.py
+++ b/td_exporter/NVMLObserver.py
@@ -147,8 +147,10 @@ class NVMLObserver:
             return False
         if self._started:
             return True
+        acquired = False
         try:
             _NVML_REFS.acquire()
+            acquired = True
             self._handle = pynvml.nvmlDeviceGetHandleByIndex(self.device)
             with contextlib.suppress(pynvml.NVMLError):
                 # Raises NVMLError_NotSupported on Linux (driver-model is Windows-only).
@@ -163,6 +165,11 @@ class NVMLObserver:
             self._started = True
             return True
         except (pynvml.NVMLError, RuntimeError, OSError) as e:
+            # Only release a ref we actually acquired — if nvmlInit() itself (inside
+            # acquire()) was what failed, release() would wrongly nvmlShutdown() an
+            # NVML that was never successfully initialized by this call.
+            if acquired:
+                _NVML_REFS.release()
             logger.warning("NVML start failed for device %d: %s", self.device, e)
             return False
 

--- a/td_exporter/TDHost.py
+++ b/td_exporter/TDHost.py
@@ -275,7 +275,7 @@ class RealTDHost(TDHost):
     def param_value(self, name: str) -> Any:
         try:
             return getattr(self._comp.par, name).eval()
-        except AttributeError:
+        except (AttributeError, RuntimeError):
             return None
 
     def set_param_value(self, name: str, value: Any) -> None:
@@ -295,7 +295,7 @@ class RealTDHost(TDHost):
             return True  # no Active par → always active (backward compat)
         try:
             return bool(self._active_par.eval())
-        except AttributeError:
+        except (AttributeError, RuntimeError):
             return True
 
     def find_top(self, name: str) -> RealTOPHandle | None:

--- a/td_exporter/TDReceiver.py
+++ b/td_exporter/TDReceiver.py
@@ -652,6 +652,12 @@ class TDReceiverEngine:
         # the outer except uses this to decide whether a targeted teardown is needed (a raise
         # after the commit must not leak the just-opened IPC/SHM handles into the next retry).
         connection_committed = False
+        # Local shm_handle opened below (line ~663). Tracked here so the outer except can close
+        # it on a raise that lands after the validation guards but before slot-loop coverage
+        # (e.g. create_stream_with_priority) — that window is outside both the validation
+        # guards' shm_handle.close() calls and _cleanup_partial's coverage, so without this it
+        # leaks the SHM mapping on every failed attempt / backoff retry.
+        shm_handle = None
         try:
             self.cuda = get_cuda_runtime(device=self.device)
             if not getattr(self, "_runtime_load_logged", False):
@@ -981,6 +987,12 @@ class TDReceiverEngine:
                 # full cleanup() here, since it also resets self._retry's backoff counters,
                 # which would make the receiver retry every frame instead of backing off.
                 self._release_resources()
+            elif shm_handle is not None:
+                # Raised after shm_handle was opened but before any validation guard's
+                # shm_handle.close() or the slot loop's _cleanup_partial coverage began
+                # (e.g. create_stream_with_priority) — close it directly so it doesn't leak.
+                with contextlib.suppress(OSError, BufferError):
+                    shm_handle.close()
 
             traceback.print_exc()
             return False

--- a/td_exporter/example_sender_launcher.py
+++ b/td_exporter/example_sender_launcher.py
@@ -22,11 +22,63 @@ TD Setup:
     4. Set Active     → ON
     5. Paste THIS script into an Execute DAT — enable Start, Frame Start, On Exit
     6. Press Play (or reopen the project) to trigger onStart()
+
+Python executable resolution (priority order) — mirrors example_receiver_launcher.py:
+    1. CUDALINK_SENDER_PYTHON_EXE env var — full path, highest priority.
+    2. Windows Python Launcher: 'py -3' resolves the system Python 3 installation
+       and returns its full path (e.g. C:\\Users\\...\\Python311\\python.exe).
+       Reliable on any Windows machine with the standard Python installer.
+    3. 'python' — bare fallback, only used if it actually resolves on PATH
+       (checked via shutil.which). If it does not resolve, onStart() prints a
+       clear error and does not spawn — a bare "python" that resolves to TD's
+       own bundled interpreter (or to nothing) fails with an opaque
+       ImportError deep in the subprocess console instead of here.
+
+    The resolved path is printed on each onStart() so you can verify which
+    interpreter is used without opening a terminal.
 """
 
 import os
+import shutil
 import signal
 import subprocess
+
+
+def _find_python_exe() -> str | None:
+    """Resolve the Python executable for the sender subprocess.
+
+    Runs once at Execute DAT load time so the path is ready before onStart().
+    Returns None only if no usable interpreter could be resolved at all.
+    """
+    # 1. Explicit env-var override — highest priority.
+    if env := os.environ.get("CUDALINK_SENDER_PYTHON_EXE", ""):
+        return env
+
+    # 2. Windows Python Launcher: 'py -3' always resolves the registered system
+    #    Python 3, regardless of PATH order.  Ask it for sys.executable so we
+    #    get the full absolute path rather than relying on 'py' staying available.
+    if shutil.which("py"):
+        try:
+            result = subprocess.run(
+                ["py", "-3", "-c", "import sys; print(sys.executable)"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return result.stdout.strip()
+        except Exception:
+            pass
+
+    # 3. Bare fallback — only if 'python' actually resolves on PATH. Unlike the
+    #    receiver launcher, we do NOT blindly return "python" here: inside a TD
+    #    Execute DAT, sys.executable resolves to TD's own bundled Python (not
+    #    the sender's env), so a PATH-less "python" would spawn something that
+    #    fails with an opaque ImportError instead of a clear message here.
+    return shutil.which("python")
+
+
+_SENDER_PYTHON_EXE = _find_python_exe()
 
 _process = None  # Sender subprocess handle
 
@@ -34,6 +86,12 @@ _process = None  # Sender subprocess handle
 def onStart() -> None:
     """Launch the Python sender as a separate subprocess."""
     global _process
+
+    if _SENDER_PYTHON_EXE is None:
+        print("[CUDA-Link Launcher] ERROR: could not resolve a Python interpreter for the sender.")
+        print("  Set CUDALINK_SENDER_PYTHON_EXE to a full python.exe path, or ensure 'py' or")
+        print("  'python' is on PATH. Not spawning — see docstring for resolution order.")
+        return
 
     script = os.path.join(project.folder, "td_exporter", "example_sender_python.py")
 
@@ -43,14 +101,15 @@ def onStart() -> None:
         return
 
     _process = subprocess.Popen(
-        ["python", script],
+        [_SENDER_PYTHON_EXE, script],
         # CREATE_NEW_CONSOLE: opens a visible console window for the sender.
         # CREATE_NEW_PROCESS_GROUP: required to send CTRL_BREAK_EVENT on shutdown
         # (CTRL_C_EVENT is blocked for new process groups on Windows).
         creationflags=subprocess.CREATE_NEW_CONSOLE | subprocess.CREATE_NEW_PROCESS_GROUP,
     )
     print(f"[CUDA-Link Launcher] Sender subprocess started  (PID {_process.pid})")
-    print(f"  Script: {script}")
+    print(f"  Script:     {script}")
+    print(f"  Python exe: {_SENDER_PYTHON_EXE}")
 
 
 def onCreate() -> None:

--- a/td_exporter/example_sender_launcher.py
+++ b/td_exporter/example_sender_launcher.py
@@ -38,6 +38,8 @@ Python executable resolution (priority order) — mirrors example_receiver_launc
     interpreter is used without opening a terminal.
 """
 
+from __future__ import annotations
+
 import os
 import shutil
 import signal

--- a/tests/cuda/test_cuda_runtime_types.py
+++ b/tests/cuda/test_cuda_runtime_types.py
@@ -1,0 +1,85 @@
+"""
+Tests for cuda_link.cuda_runtime_types ABI guards.
+
+Background
+----------
+The module-level struct-size guards used to be plain ``assert`` statements. Asserts are
+stripped when Python runs with the ``-O`` (optimize) flag, so a ctypes struct-layout drift
+(e.g. from a platform/compiler ABI change) would import silently instead of failing loudly.
+They were replaced with an explicit ``_abi_guard()`` helper that raises ``RuntimeError``
+unconditionally, regardless of ``-O``.
+
+These tests are GPU-free — they only touch ctypes struct definitions.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# The repo's pyproject.toml adds "src" to pytest's `pythonpath` ini option, so imports work
+# in-process without an editable install. A bare subprocess doesn't get that for free — it
+# would silently fall back to whatever `cuda_link` happens to be installed in site-packages
+# (which may be stale). Explicitly prepend src/ to PYTHONPATH so the subprocess imports the
+# same source tree these tests are validating.
+_SRC_DIR = str(Path(__file__).resolve().parents[2] / "src")
+
+
+def _subprocess_env() -> dict[str, str]:
+    env = dict(os.environ)
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = _SRC_DIR if not existing else f"{_SRC_DIR}{os.pathsep}{existing}"
+    return env
+
+
+def test_abi_guard_passes_for_correct_size() -> None:
+    """_abi_guard() is a no-op when actual == expected."""
+    from cuda_link.cuda_runtime_types import _abi_guard
+
+    _abi_guard(64, 64, "some_struct")  # must not raise
+
+
+def test_abi_guard_raises_runtime_error_on_mismatch() -> None:
+    """_abi_guard() raises RuntimeError (not AssertionError) on a size mismatch."""
+    from cuda_link.cuda_runtime_types import _abi_guard
+
+    with pytest.raises(RuntimeError, match="ABI mismatch"):
+        _abi_guard(63, 64, "some_struct")
+
+
+def test_module_imports_cleanly_under_dash_o() -> None:
+    """Regression: the ABI guards must not be assert statements.
+
+    Under `python -O`, `assert` statements are stripped entirely. If the guards were still
+    asserts, a real struct-size drift would import silently instead of raising. This test
+    can't directly force a drift (the structs are hardcoded correctly), so it instead proves
+    the guard mechanism survives -O by checking the module imports cleanly and _abi_guard is
+    still callable and still raises on a synthetic mismatch, all inside a `python -O` subprocess.
+    """
+    code = "import cuda_link.cuda_runtime_types as m\nm._abi_guard(1, 2, 'synthetic')\n"
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=_subprocess_env(),
+    )
+    assert result.returncode != 0, "expected _abi_guard to raise under -O, but process exited cleanly"
+    assert "RuntimeError" in result.stderr
+    assert "ABI mismatch" in result.stderr
+
+
+def test_module_imports_cleanly_under_dash_o_with_real_structs() -> None:
+    """The real module-level guards (correct sizes) must import cleanly under -O."""
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", "import cuda_link.cuda_runtime_types"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=_subprocess_env(),
+    )
+    assert result.returncode == 0, f"import failed under -O:\n{result.stderr}"

--- a/tests/cuda/test_nvml_observer.py
+++ b/tests/cuda/test_nvml_observer.py
@@ -285,3 +285,54 @@ def test_ref_count_multiple_observers() -> None:
 
         obs2.stop()
         assert mock_pynvml.nvmlShutdown.call_count == 1  # final ref released
+
+
+def test_ref_count_released_when_start_fails_after_acquire() -> None:
+    """A failure after acquire() (e.g. nvmlDeviceGetHandleByIndex raises) must not leak the ref.
+
+    Regression test for: start() called _NVML_REFS.acquire() (which calls nvmlInit()) then
+    nvmlDeviceGetHandleByIndex() raised. Before the fix, the except block returned False
+    without releasing the ref — _NVML_REFS._count stayed at 1 forever and nvmlShutdown() was
+    never called, even though _started stayed False (so stop() could never release it either).
+    """
+    mock_pynvml = _make_mock_pynvml()
+    mock_pynvml.nvmlDeviceGetHandleByIndex.side_effect = _NVMLError("device not found")
+
+    with patch("cuda_link.nvml_observer.pynvml", mock_pynvml), patch("cuda_link.nvml_observer.NVML_AVAILABLE", True):
+        import cuda_link.nvml_observer as nvml_mod
+        from cuda_link.nvml_observer import NVMLObserver
+
+        nvml_mod._NVML_REFS._count = 0
+
+        obs = NVMLObserver(device=0, enabled=True)
+        assert obs.start() is False
+        assert obs._started is False
+
+        # The failed attempt must not leave a dangling ref.
+        assert nvml_mod._NVML_REFS._count == 0
+        assert mock_pynvml.nvmlInit.call_count == 1  # acquire() did call nvmlInit()
+        assert mock_pynvml.nvmlShutdown.call_count == 1  # ...and it was released on failure
+
+
+def test_repeated_failed_start_does_not_compound_ref_count() -> None:
+    """A persistently-failing NVML init must not compound the ref count across retries.
+
+    start() sits on the export/import hot path (callers: __enter__, export_frame,
+    import_frame) — since _started stays False after a failure, a caller may legitimately
+    call start() again on the next frame. Each failed attempt must net to zero.
+    """
+    mock_pynvml = _make_mock_pynvml()
+    mock_pynvml.nvmlDeviceGetHandleByIndex.side_effect = _NVMLError("still not found")
+
+    with patch("cuda_link.nvml_observer.pynvml", mock_pynvml), patch("cuda_link.nvml_observer.NVML_AVAILABLE", True):
+        import cuda_link.nvml_observer as nvml_mod
+        from cuda_link.nvml_observer import NVMLObserver
+
+        nvml_mod._NVML_REFS._count = 0
+
+        obs = NVMLObserver(device=0, enabled=True)
+        for _ in range(3):
+            assert obs.start() is False
+
+        assert nvml_mod._NVML_REFS._count == 0
+        assert mock_pynvml.nvmlInit.call_count == mock_pynvml.nvmlShutdown.call_count == 3

--- a/tests/td/test_example_sender_launcher.py
+++ b/tests/td/test_example_sender_launcher.py
@@ -1,0 +1,66 @@
+"""
+Regression test: example_sender_launcher._find_python_exe() / onStart() must not fall back
+to spawning a bare, unverified "python" when no interpreter can be resolved (#4 in the
+td_exporter audit).
+
+Background: the sibling receiver launcher (example_receiver_launcher.py) blindly returns the
+literal string "python" as its final fallback -- if nothing is actually on PATH, Popen raises
+deep inside the subprocess with an opaque error. The sender launcher was hardened instead: its
+final fallback checks shutil.which("python") and returns None if it doesn't resolve, and
+onStart() prints a clear, actionable error and returns without spawning anything (and without
+touching the TD `project` global, which does not exist outside a TouchDesigner process).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
+
+
+def _reset_module():
+    """(Re)import example_sender_launcher fresh so module-level globals (_process,
+    _SENDER_PYTHON_EXE) don't bleed state between tests."""
+    import example_sender_launcher as mod
+
+    importlib.reload(mod)
+    return mod
+
+
+def test_find_python_exe_returns_none_when_nothing_resolves(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_find_python_exe() must return None (not the bare string 'python') when no
+    interpreter can be resolved via env var, 'py -3', or PATH."""
+    mod = _reset_module()
+
+    monkeypatch.delenv("CUDALINK_SENDER_PYTHON_EXE", raising=False)
+    monkeypatch.setattr(mod.shutil, "which", lambda name: None)
+
+    result = mod._find_python_exe()
+    assert result is None, "must return None, not silently fall back to an unverified bare 'python'"
+
+
+def test_onstart_does_not_spawn_when_no_interpreter_resolved(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """onStart() must not call subprocess.Popen -- and must not touch the TD `project`
+    global -- when _SENDER_PYTHON_EXE is None; it should print a clear error and return."""
+    mod = _reset_module()
+
+    monkeypatch.setattr(mod, "_SENDER_PYTHON_EXE", None)
+    mock_popen = MagicMock()
+    monkeypatch.setattr(mod.subprocess, "Popen", mock_popen)
+
+    mod.onStart()  # must return before referencing `project.folder` (undefined outside TD)
+
+    mock_popen.assert_not_called()
+    assert mod._process is None
+
+    captured = capsys.readouterr()
+    assert "ERROR" in captured.out
+    assert "CUDALINK_SENDER_PYTHON_EXE" in captured.out

--- a/tests/td/test_td_host.py
+++ b/tests/td/test_td_host.py
@@ -24,6 +24,15 @@ class _TDParValue:
         return self._v
 
 
+class _RaisingParValue(_TDParValue):
+    """Simulates a TD par in an error state: .eval() raises RuntimeError/tdError,
+    not AttributeError. Used to test the #5a hardening (param_value/is_active must
+    catch RuntimeError alongside AttributeError, matching the sibling find_top)."""
+
+    def eval(self) -> Any:
+        raise RuntimeError("simulated TD param eval failure")
+
+
 class _TDPar:
     def __init__(self, **kwargs: Any) -> None:
         self._attrs: dict[str, _TDParValue] = {}
@@ -309,6 +318,31 @@ def test_real_td_host_is_active_no_par_defaults_true() -> None:
     from TDHost import RealTDHost
 
     comp = _TDComp()  # no Active parameter
+    host = RealTDHost(comp)
+
+    assert host.is_active() is True
+
+
+def test_real_td_host_param_value_runtime_error_returns_none() -> None:
+    """param_value() must catch RuntimeError (not just AttributeError) — a param that
+    exists but is in an error state raises RuntimeError/tdError from .eval(), and the
+    per-frame path must not propagate it. Matches the sibling find_top()'s except clause."""
+    from TDHost import RealTDHost
+
+    comp = _TDComp(Mode="Sender")
+    comp.par._attrs["Mode"] = _RaisingParValue("Sender")
+    host = RealTDHost(comp)
+
+    assert host.param_value("Mode") is None
+
+
+def test_real_td_host_is_active_runtime_error_defaults_true() -> None:
+    """is_active() must catch RuntimeError from Active.eval() (param in an error state)
+    and fail open (True) instead of propagating, matching the sibling find_top()."""
+    from TDHost import RealTDHost
+
+    comp = _TDComp(Active=True)
+    comp.par._attrs["Active"] = _RaisingParValue(True)
     host = RealTDHost(comp)
 
     assert host.is_active() is True

--- a/tests/td/test_tdreceiver_shm_leak.py
+++ b/tests/td/test_tdreceiver_shm_leak.py
@@ -1,0 +1,183 @@
+"""
+Regression test: TDReceiverEngine.initialize_receiver() must not leak the locally-opened
+shm_handle when a later step raises before the connection is committed.
+
+Bug (#5b in the td_exporter audit, TDReceiver.py): initialize_receiver() opens `shm_handle`
+early via `SharedMemory(name=self.shm_name)`. Every validation-guard failure closes it
+explicitly, and every slot-loop failure routes through `_cleanup_partial(...)`, which also
+closes it. But `create_stream_with_priority` (called after all validation guards, before the
+slot loop -- TDReceiver.py ~797) sat outside both: a raise there hit the outer `except` while
+`connection_committed` was still False, and the outer except only closed the handle when
+`connection_committed` was True. Result: every failed attempt -- and every backoff retry --
+leaked the SHM mapping.
+
+Fix: track `shm_handle` independently of `connection_committed` and close it in the outer
+`except` whenever it was opened but the connection was never committed.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+import uuid
+from multiprocessing.shared_memory import SharedMemory
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+
+def _make_receiver(shm_name: str):
+    from TDConfig import TDSenderConfig
+    from TDHost import TDHost
+    from TDReceiver import TDReceiverEngine
+
+    class _NullHost(TDHost):
+        def __init__(self):
+            self.cuda_shapes = []
+
+        def param_value(self, name):
+            return {"Active": True, "Debug": False}.get(name)
+
+        def set_param_value(self, name, value):
+            pass
+
+        def set_param_enabled(self, name, enabled):
+            pass
+
+        def show_custom_only(self, value):
+            pass
+
+        def is_active(self):
+            return True
+
+        def find_top(self, name):
+            return None
+
+        def wrap_top(self, top):
+            return top
+
+        def make_cuda_shape(self, width, height, num_comps, data_type):
+            shape = type(
+                "_Shape",
+                (),
+                {"width": width, "height": height, "numComps": num_comps, "dataType": data_type},
+            )()
+            self.cuda_shapes.append(shape)
+            return shape
+
+        def set_warning_status(self, msg):
+            pass
+
+        def set_error_status(self, msg):
+            pass
+
+        def clear_status(self):
+            pass
+
+        def set_info_status(self, msg):
+            pass
+
+    config = TDSenderConfig()
+    return TDReceiverEngine(
+        host=_NullHost(),
+        config=config,
+        cuda=None,
+        log_fn=lambda *a, **k: None,
+        num_slots=1,
+        device=0,
+        shm_name=shm_name,
+        verbose=False,
+    )
+
+
+def _write_valid_shm_frame(shm: SharedMemory) -> None:
+    """Write a minimal-but-fully-valid header + metadata so initialize_receiver() sails
+    through every validation guard and reaches the stream-creation step."""
+    from cuda_link.shm_protocol import FORMAT_KIND_FLOAT, Metadata, SHMLayout
+
+    layout = SHMLayout(num_slots=1)
+    W, H, C = 64, 64, 4
+    shm.buf[: layout.total_size] = layout.build_buffer(version=1, write_idx=0)
+    Metadata(
+        width=W,
+        height=H,
+        num_comps=C,
+        format_kind=FORMAT_KIND_FLOAT,
+        bits_per_comp=32,
+        flags=0,
+        data_size=W * H * C * 4,
+    ).pack_into(memoryview(shm.buf), layout)
+
+
+class _FakeCudaFailsOnStreamCreate:
+    """Fake CUDA adapter: succeeds through get_device(), raises on stream creation -- the
+    exact call (create_stream_with_priority, TDReceiver.py ~797) that sits outside both the
+    validation guards' shm_handle.close() calls and _cleanup_partial's coverage."""
+
+    def get_device(self) -> int:
+        return 0
+
+    def create_stream_with_priority(self, flags: int):  # noqa: ARG002
+        raise RuntimeError("simulated stream creation failure")
+
+
+def test_initialize_receiver_closes_shm_on_stream_create_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED before the #5b fix: a raise from create_stream_with_priority must close the
+    locally-opened shm_handle instead of leaking it (leaks compound on every backoff retry)."""
+    import TDReceiver as TDReceiverMod
+
+    from cuda_link.shm_protocol import SHMLayout
+
+    shm_name = f"test_shm_leak_{uuid.uuid4().hex[:8]}"
+    layout = SHMLayout(num_slots=1)
+    producer_shm = SharedMemory(create=True, name=shm_name, size=layout.total_size)
+
+    tracked: list = []
+
+    class _TrackingSharedMemory(SharedMemory):
+        """Wraps SharedMemory to record whether close() was called on this instance.
+
+        Installed as TDReceiver's module-level SharedMemory name, so only the receiver's
+        internally-opened handle (via `SharedMemory(name=self.shm_name)`) is tracked -- the
+        producer handle above is a plain, unpatched SharedMemory.
+        """
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.close_called = False
+            tracked.append(self)
+
+        def close(self):
+            self.close_called = True
+            super().close()
+
+    try:
+        _write_valid_shm_frame(producer_shm)
+
+        monkeypatch.setattr(TDReceiverMod, "get_cuda_runtime", lambda device: _FakeCudaFailsOnStreamCreate())
+        monkeypatch.setattr(TDReceiverMod, "SharedMemory", _TrackingSharedMemory)
+
+        engine = _make_receiver(shm_name)
+
+        result = engine.initialize_receiver()
+
+        assert result is False, "initialize_receiver() must return False when stream creation raises"
+        assert len(tracked) == 1, f"expected exactly one receiver-side SharedMemory open, got {len(tracked)}"
+        assert tracked[0].close_called is True, (
+            "shm_handle.close() must be called when create_stream_with_priority raises before "
+            "connection_committed is set -- otherwise the SHM mapping leaks on every backoff retry"
+        )
+        assert engine._connection.shm_handle is None, (
+            "a failed attempt must not commit its shm_handle onto self._connection"
+        )
+    finally:
+        producer_shm.close()
+        with contextlib.suppress(FileNotFoundError):
+            producer_shm.unlink()

--- a/tests/td/test_tdreceiver_shm_leak.py
+++ b/tests/td/test_tdreceiver_shm_leak.py
@@ -32,7 +32,7 @@ sys.path.insert(0, str(_REPO_ROOT / "src"))
 
 
 def _make_receiver(shm_name: str):
-    from TDConfig import TDSenderConfig
+    from TDConfig import TDReceiverConfig
     from TDHost import TDHost
     from TDReceiver import TDReceiverEngine
 
@@ -82,7 +82,7 @@ def _make_receiver(shm_name: str):
         def set_info_status(self, msg):
             pass
 
-    config = TDSenderConfig()
+    config = TDReceiverConfig()
     return TDReceiverEngine(
         host=_NullHost(),
         config=config,


### PR DESCRIPTION
## Changes

- 8dab7eb fix: close resource leaks and harden error handling in td_exporter (audit #2-#5)

## Branch

`fix/td-exporter-resource-leaks` -> `development`