### PR TITLE
ci: harden pipeline — SHA-pin actions, scope permissions, blocking ruff, native-build gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Keeps SHA-pinned actions current: Dependabot rewrites the pin and its version
+# comment together in one grouped weekly PR per ecosystem.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      python-deps:
+        patterns:
+          - "*"

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -18,6 +18,13 @@ on:
       - 'TD_RAG/**'
       - 'References/**'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: Validate Branch State
@@ -25,9 +32,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0  # Full history for branch comparison
+          persist-credentials: false
 
       - name: Check for local-only files
         run: |
@@ -101,10 +109,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.9'
           cache: 'pip'
@@ -121,7 +131,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: test-results
           path: test-results/
@@ -134,28 +144,25 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.9'
 
       - name: Install linting tools
+        # Pinned so a new ruff release adding rules can't turn this blocking gate
+        # red overnight; bump deliberately alongside .pre-commit-config.yaml.
         run: |
-          pip install ruff
+          pip install "ruff==0.14.13"
 
       - name: Run ruff check (linting + import sorting)
-        run: ruff check .
-        continue-on-error: true
+        run: ruff check --output-format=github .
 
       - name: Check formatting (ruff format)
         run: ruff format --check .
-        continue-on-error: true
 
-      - name: Install type checker
-        run: pip install pyrefly
-
-      - name: Run type checking (pyrefly)
-        run: pyrefly check
-        continue-on-error: true
+      # pyrefly runs as its own blocking gate in typecheck.yml — not duplicated here.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,14 +29,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
         continue-on-error: true  # Don't fail PR status if Claude has issues
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342  # v1.0.171
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "*"  # Allow all bots (including claude[bot])

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,13 +34,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342  # v1.0.171
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "*"  # Allow all bots (including claude[bot])

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -11,6 +11,13 @@ on:
       - 'docs/**'
       - 'README.md'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   markdown-lint:
     name: Markdown Linting
@@ -18,10 +25,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v15
+        uses: DavidAnson/markdownlint-cli2-action@510b996878fc0d1a46c8a04ec86b06dbfba09de7  # v15.0.0
         with:
           globs: |
             **/*.md
@@ -37,10 +46,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Check documentation links
-        uses: lycheeverse/lychee-action@v1
+        uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621  # v1.10.0
         with:
           args: |
             --verbose
@@ -59,10 +70,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Check spelling
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14  # v1.48.0
         with:
           files: docs/ README.md
         continue-on-error: true

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -1,0 +1,67 @@
+name: Native Build
+
+# Per-PR compile check for the _native_waiter C++ extension. release.yml builds
+# the same wheel at tag time; this workflow catches CMake/MSVC breakage when it
+# lands, not weeks later at release. Steps mirror release.yml's build-wheels job
+# (native wheel only — the py3-none-any fallback wheel compiles nothing, so it
+# can't break and isn't rebuilt here).
+
+on:
+  push:
+    branches: [development, main, master]
+    paths:
+      - 'src/cuda_link/_cpp/**'
+      - 'CMakeLists.txt'
+      - 'pyproject.toml'
+      - '.github/workflows/native-build.yml'
+  pull_request:
+    paths:
+      - 'src/cuda_link/_cpp/**'
+      - 'CMakeLists.txt'
+      - 'pyproject.toml'
+      - '.github/workflows/native-build.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-native:
+    name: Build native wheel (Windows)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install build frontend
+        run: python -m pip install --upgrade pip build
+
+      - name: Sync td_exporter/CUDAIPCWrapper.py from canonical source
+        run: python scripts/sync_td_wrapper.py
+
+      - name: Build native wheel (compiles _native_waiter)
+        # BUILD_NATIVE_WAITER defaults ON on Windows — no flag needed.
+        run: python -m build --wheel
+
+      - name: Install wheel and run native state-machine tests
+        # test_native_state_machine.py needs only the compiled extension (no
+        # GPU/cudart) — same smoke test release.yml runs at tag time.
+        shell: pwsh
+        run: |
+          $wheel = Get-ChildItem dist\cuda_link-*-cp311-cp311-win_amd64.whl | Select-Object -First 1
+          python -m pip install "$($wheel.FullName)"
+          python -c "import cuda_link._native_waiter; print('native extension imported OK')"
+          python -m pip install pytest pytest-randomly
+          pytest tests/core/test_native_state_machine.py -m requires_native -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,10 @@ on:
     tags: ['v*']
   workflow_dispatch:
 
+# Read-only by default; only the release job below needs write (to create the
+# GitHub Release). The build job compiles wheels and must not hold a write token.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   # Windows-only: cuda-link is locked to Windows (see docs/adr/0013-prebuilt-wheel-distribution.md),
@@ -18,13 +20,17 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.11'
-          cache: pip
+          # No pip cache here: this job builds the wheels that ship in the GitHub
+          # Release, and a poisoned shared cache could inject code into them
+          # (zizmor cache-poisoning audit). CI-only builds keep their cache.
 
       - name: Install build frontend
         run: python -m pip install --upgrade pip build
@@ -62,7 +68,7 @@ jobs:
           pytest tests/core/test_native_state_machine.py -m requires_native -v
 
       - name: Upload wheels artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: wheels
           path: dist/cuda_link-*.whl
@@ -72,16 +78,19 @@ jobs:
     name: Create GitHub Release
     needs: build-wheels
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # create the GitHub Release + upload assets
     # workflow_dispatch runs (no tag) build + smoke-test the wheels above but stop
     # there -- softprops/action-gh-release requires an actual tag ref to attach to.
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download built wheels
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
         with:
           name: wheels
           path: dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,13 @@ on:
       - 'scripts/sync_td_wrapper.py'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pytest:
     name: pytest (no GPU) — Python ${{ matrix.python-version }}
@@ -33,10 +40,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -66,7 +75,7 @@ jobs:
         run: pytest tests/ -m "not requires_cuda and not requires_native" --cov=cuda_link --cov-report=term-missing --cov-report=xml -q
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5.5.5
         with:
           files: ./coverage.xml
           flags: main
@@ -77,7 +86,7 @@ jobs:
 
       - name: Upload coverage report artifact
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: coverage-main-${{ matrix.python-version }}
           path: coverage.xml

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -15,6 +15,13 @@ on:
       - 'pyproject.toml'
       - '.github/workflows/typecheck.yml'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pyrefly:
     name: pyrefly (static type check)
@@ -22,10 +29,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.11'
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,22 @@
+# Codecov posture: patch coverage (new/changed lines) is the gate that matters —
+# "test what you write". Project-wide coverage is informational only here because
+# the hard project floor is already enforced inside CI itself by
+# [tool.coverage.report] fail_under in pyproject.toml (ratcheted; see the comment
+# there for the measured baseline and the T2 ratchet plan).
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        threshold: 0%
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Changes

- a4f76a9 ci: harden pipeline — SHA-pin actions, scope permissions, blocking ruff, native-build gate

## Branch

`ci/pipeline-hardening` -> `development`