### PR TITLE
merge: fix/cuda-ipc-verification-findings -> development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`cudaDevAttrAsyncEngineCount` documented as attribute 4** (`cuda_ipc_wrapper.py`) — the
   real value is 40; 4 is `cudaDevAttrMaxBlockDimZ`. Latent (no production caller queried it
   yet), but corrected before it could be relied on.
+- **IPC capability probe aborted initialization on CUDA 11.x** (`cuda_ipc_wrapper.py`) —
+  `check_ipc_capability()`, added earlier in this release and called unconditionally from
+  `Exporter.open()`, queries `cudaDevAttrIpcEventSupport` (125), which CUDA 12.0 introduced.
+  An 11.x runtime — still probed by the loader, and what TouchDesigner ships as
+  `cudart64_110.dll` — returns an invalid-attribute error that the strict `errcheck` turned
+  into a hard failure. The probe is now version-gated and its query is non-fatal, so a failed
+  probe degrades to a logged diagnostic; only an explicit `cudaDevAttrIpcEventSupport == 0`
+  still raises.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.2] - 2026-08-10
+
+### Fixed
+
+- **`cudaPointerAttributes` undersized against CUDA 13.x** (`cuda_runtime_types.py`) — the
+  struct grew a `long reserved[8]` field in CUDA 13.x driver_types.h (56 bytes vs. 24 in
+  12.x), but the ctypes binding still declared the 24-byte 12.x layout and the ABI guard
+  hard-checked that literal. The loader probes 13.3 before 12.x, so `pointer_get_attributes()`
+  — on the per-frame device-affinity path — was passing an undersized out-parameter to a
+  13.x cudart. Extended the struct with the `reserved` field and raised the guard to 56;
+  over-sizing is safe against both runtime generations, so no version branching is needed.
+- **`cudaDevAttrAsyncEngineCount` documented as attribute 4** (`cuda_ipc_wrapper.py`) — the
+  real value is 40; 4 is `cudaDevAttrMaxBlockDimZ`. Latent (no production caller queried it
+  yet), but corrected before it could be relied on.
+
+### Added
+
+- **`check_ipc_capability()`** on the `CudaPort` protocol, `CTypesCUDAAdapter`, and
+  `FakeCUDAAdapter`, called once from `Exporter.open()` before any IPC handle is minted.
+  Queries `cudaDevAttrIpcEventSupport` and logs an informational note about the
+  Windows-WDDM-vs-NVIDIA-documented-support gap (see ADR-0004) rather than hard-failing,
+  since this project's whole premise is that legacy CUDA IPC works there in practice; raises
+  only when the driver reports IPC flatly unsupported (`cudaDevAttrIpcEventSupport == 0`).
+
+### Docs
+
+- Corrected the inverted CUDA-IPC platform-support claim in `README.md` and
+  `td_exporter/HELP_DOC.md` — NVIDIA documents the legacy IPC API as Linux/Windows-TCC only;
+  this project runs it on Windows WDDM, which is validated in practice (ADR-0004) but
+  outside NVIDIA's documented support envelope.
+- Fixed the stale 14-mirror-DAT count (actual: 15) across `README.md`, `ARCHITECTURE.md`,
+  the ADRs, and `TOX_BUILD_GUIDE.md` — the latter previously instructed builders to add "14
+  mirror DATs," silently omitting `Doorbell`.
+
 ## [1.12.1] - 2026-07-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -47,9 +47,13 @@ Measured on RTX 4090 / PCIe 4.0 x16 / Windows 11 / driver 596.36. All Python-sid
 
 ## Requirements
 
-- **OS**: Windows 10/11 (CUDA IPC is Windows-only)
-- **CUDA**: 12.x (tested with 12.4)
-- **GPU**: NVIDIA GPU with CUDA compute capability 3.5+
+- **OS**: Windows 10/11. NVIDIA documents the legacy `cudaIpc*` API as Linux-only, and on
+  Windows as supported only under the TCC driver model — this project runs it on the
+  default WDDM driver model instead, which works in practice (see
+  [ADR-0004](docs/adr/0004-legacy-cuda-ipc-over-vmm.md)) but is outside NVIDIA's documented
+  support envelope.
+- **CUDA**: 11.x / 12.x / 13.x (the loader prefers 13.x, then 12.x; tested with 12.4 and 12.8)
+- **GPU**: Any NVIDIA GPU supporting the CUDA runtime IPC and Graphs APIs used above
 - **TouchDesigner**: 2022.x or later (for producer side)
 - **Python**: 3.11+ recommended (for consumer side; matches TouchDesigner's bundled interpreter). The pure-Python fallback wheel also installs on 3.9+ — see [Distribution](#distribution).
 
@@ -87,7 +91,7 @@ See [`docs/TOX_BUILD_GUIDE.md`](docs/TOX_BUILD_GUIDE.md) for step-by-step assemb
 **Option C: Library mode (cleaner .tox — fewer Text DATs)**
 
 For a leaner `.tox` (package installed once into a Python environment TD can see, instead
-of 14 mirror Text DATs), see [Distribution → For TouchDesigner Integration](#for-touchdesigner-integration).
+of 15 mirror Text DATs), see [Distribution → For TouchDesigner Integration](#for-touchdesigner-integration).
 
 ### 2. Python Side (Importer)
 
@@ -492,7 +496,7 @@ Follow the manual build guide at [`docs/TOX_BUILD_GUIDE.md`](docs/TOX_BUILD_GUID
 **Option C: Library mode (cleaner .tox — fewer Text DATs)**
 
 Install `cuda_link` into a Python environment TouchDesigner can see. The `CUDALinkBootstrap`
-DAT then loads the package automatically — the 14 mirror Text DATs (Env, SHMProtocol,
+DAT then loads the package automatically — the 15 mirror Text DATs (Env, SHMProtocol,
 Exporter, Importer, …) are no longer needed in the `.tox`. Run the multi-target installer
 (one-time):
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,8 +117,8 @@ CUDAIPCExtension  (~300 LOC facade)
 
 **Two deployment modes** — `CUDALinkBootstrap` (a new Text DAT, the first import in `CUDAIPCExtension.py`) enables a choice at COMP init:
 
-- **Library mode** (recommended): install `cuda_link` into an external folder with `install_td_library.cmd`; set `CUDALINK_LIB_PATH` to that folder before launching TD. The bootstrap injects the folder onto `sys.path` and registers all 14 mirror module names as `sys.modules` aliases to the installed `cuda_link.*` submodules — so the 14 mirror Text DATs can be removed from the `.tox` entirely.
-- **Fallback / classic mode**: if `CUDALINK_LIB_PATH` is unset or the import fails, the bootstrap silently no-ops. All 14 mirror Text DATs must be present in the COMP (the original deployment story, unchanged). See ADR-0003 for rationale.
+- **Library mode** (recommended): install `cuda_link` into an external folder with `install_td_library.cmd`; set `CUDALINK_LIB_PATH` to that folder before launching TD. The bootstrap injects the folder onto `sys.path` and registers all 15 mirror module names as `sys.modules` aliases to the installed `cuda_link.*` submodules — so the 15 mirror Text DATs can be removed from the `.tox` entirely.
+- **Fallback / classic mode**: if `CUDALINK_LIB_PATH` is unset or the import fails, the bootstrap silently no-ops. All 15 mirror Text DATs must be present in the COMP (the original deployment story, unchanged). See ADR-0003 for rationale.
 
 ---
 
@@ -427,7 +427,7 @@ it on every subsequent frame.  The graph folds `stream_wait_event` + `cudaMemcpy
 kernel dispatches.
 
 **Effect**: 3 WDDM submissions/frame → 1.  Measured gain at 1080p uint8 standalone:
-−3.8 µs p50 (22%) from 17.9 µs (async, no graphs) to 13.9 µs (async+graphs).  See
+−4.0 µs p50 (22%) from 17.9 µs (async, no graphs) to 13.9 µs (async+graphs).  See
 [docs/BENCHMARKS.md](BENCHMARKS.md) for the full 2×2 matrix.
 
 Graph replay is transparent: on the first frame after a geometry or dtype change the graph is
@@ -490,7 +490,7 @@ the function returns immediately — preventing a stall of up to `timeout_secs`.
 - Teardown: IPC handles close in ~0.6 ms (no 2 s hang, no orphaned handles)
 
 **Scope and limitations**:
-- Windows-only (`CreateNamedEvent` / `WaitForSingleObject`).
+- Windows-only (`CreateEventW` / `WaitForSingleObject`).
 - Single consumer only — one `SetEvent` releases exactly one waiter.
 - `TDReceiver.py` (in-TD COMP on the cook thread) is **excluded** from doorbell wiring; it returns
   immediately on `NO_FRAME` and must not block in a cook context.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -72,7 +72,7 @@ graphs ON → 1 submission/frame (`cudaGraphLaunch`, 550 calls; waitEvent/eventR
 Region            Cell A (µs)   Cell D (µs)   Notes
 --------------    -----------   -----------   ----------------------------------------
 stream_wait            1.26          0.00     folded into CUDA graph (P3)
-memcpy                 7.76          6.77     PCIe-bound, ~22 GB/s
+memcpy                 7.76          6.77     device-to-device (same GPU), HBM-bound, ~1 TB/s class
 record_event           4.50          0.00     folded into CUDA graph (P3)
 shm_write              1.92          1.21     SHM slot write (unaffected)
 sync                  17.91          0.00     cudaStreamSynchronize eliminated (P1)

--- a/docs/INTEGRATION_EXAMPLES.md
+++ b/docs/INTEGRATION_EXAMPLES.md
@@ -511,7 +511,7 @@ wait — measured CPU usage: ~3-4% → ~0.3-1% at 60 FPS.
 
 ### Requirements
 
-- Windows only (Win32 `CreateNamedEvent`)
+- Windows only (Win32 `CreateEventW`)
 - `CUDALINK_DOORBELL=1` set on **both** TD Sender and Python consumer before either process starts
 - Single consumer per channel only
 

--- a/docs/TOX_BUILD_GUIDE.md
+++ b/docs/TOX_BUILD_GUIDE.md
@@ -16,7 +16,7 @@ There are two assembly modes. Choose one:
 
 Requires `cuda_link` installed externally (`install_td_library.cmd`) and `CUDALINK_LIB_PATH`
 set before launching TouchDesigner. The bootstrap module loads the package and registers the
-14 mirror names in `sys.modules` — so those mirror Text DATs are not needed.
+15 mirror names in `sys.modules` — so those mirror Text DATs are not needed.
 
 ```
 CUDAIPCExporter (Base COMP)
@@ -37,7 +37,7 @@ CUDAIPCExporter (Base COMP)
 
 ### Classic / fallback mode (no install required — all mirror DATs included)
 
-All 14 mirror Text DATs must be present. The bootstrap still silently no-ops if
+All 15 mirror Text DATs must be present. The bootstrap still silently no-ops if
 `CUDALINK_LIB_PATH` is unset — sibling import resolution works as before.
 
 ```
@@ -51,6 +51,7 @@ CUDAIPCExporter (Base COMP)
 ├── NVMLObserver      (Text DAT)     ← Copy from td_exporter/NVMLObserver.py
 ├── SHMProtocol       (Text DAT)     ← Copy from td_exporter/SHMProtocol.py
 ├── ActivationBarrier (Text DAT)     ← Copy from td_exporter/ActivationBarrier.py
+├── Doorbell          (Text DAT)     ← Copy from td_exporter/Doorbell.py
 ├── NVTXShim          (Text DAT)     ← Copy from td_exporter/NVTXShim.py
 ├── ExporterPort      (Text DAT)     ← Copy from td_exporter/ExporterPort.py
 ├── ImporterPort      (Text DAT)     ← Copy from td_exporter/ImporterPort.py
@@ -114,7 +115,7 @@ Click the **+** button to add a new parameter page, name it `"CUDA IPC"`.
 ### Step 3: Create Text DATs
 
 **Library mode** (with `cuda_link` installed via `install_td_library.cmd`): create the 6 DATs
-in section 3a–3f only — the 14 mirror DATs (3g+) are resolved from the installed package.
+in section 3a–3f only — the 15 mirror DATs (3g+) are resolved from the installed package.
 
 **Classic/fallback mode** (no install): create ALL DATs in sections 3a–3q.
 
@@ -180,7 +181,7 @@ This module provides `TDReceiverEngine` — the Receiver-mode engine that owns S
 
 ---
 
-**Classic/fallback mode only — add these 14 mirror DATs (Steps 3g–3q):**
+**Classic/fallback mode only — add these 15 mirror DATs (Steps 3g–3i):**
 
 #### 3g. Env / FrameProfile / CUDAIPCWrapper / CUDARuntimeTypes / CUDAGraphs Text DATs
 
@@ -194,13 +195,14 @@ For each, create a **Text DAT** with the name shown and paste the matching file:
 | `CUDARuntimeTypes` | `td_exporter/CUDARuntimeTypes.py` |
 | `CUDAGraphs` | `td_exporter/CUDAGraphs.py` |
 
-#### 3h. NVMLObserver / SHMProtocol / ActivationBarrier / NVTXShim Text DATs
+#### 3h. NVMLObserver / SHMProtocol / ActivationBarrier / Doorbell / NVTXShim Text DATs
 
 | DAT name | Source file |
 |---|---|
 | `NVMLObserver` | `td_exporter/NVMLObserver.py` |
 | `SHMProtocol` | `td_exporter/SHMProtocol.py` |
 | `ActivationBarrier` | `td_exporter/ActivationBarrier.py` |
+| `Doorbell` | `td_exporter/Doorbell.py` |
 | `NVTXShim` | `td_exporter/NVTXShim.py` |
 
 #### 3i. ExporterPort / ImporterPort / CUDAAdapters / Exporter / Importer Text DATs

--- a/docs/adr/0004-legacy-cuda-ipc-over-vmm.md
+++ b/docs/adr/0004-legacy-cuda-ipc-over-vmm.md
@@ -16,9 +16,21 @@ CUDA 12.8+"* — arguing for migration to the VMM driver API
 (`cuMemCreate` + `CU_MEM_HANDLE_TYPE_WIN32` + `DuplicateHandle`) and claiming that legacy
 `cudaIpc*` memory IPC is Linux-only and fails on Windows WDDM with error 801.
 
-That claim is empirically refuted by this codebase: production IPC has been validated on Windows WDDM with
-CUDA 12.x across multiple format variants and teardown/reconnect cycles with no error 801. The "err 801"
-arises on the `torch.multiprocessing` IPC path, not on raw `cudaIpcGetMemHandle` / `cudaIpcOpenMemHandle`.
+NVIDIA's own documentation supports the "Linux-only" half of that claim. CUDA Programming Guide §4.15:
+*"The CUDA IPC API is only currently supported on Linux platforms."* §4.15.1 repeats it: *"The IPC API is
+only supported on Linux."* The `simpleIPC` sample gates its Windows path explicitly:
+`// CUDA IPC on Windows is only supported on TCC`, followed by
+`if (!prop.tccDriver) { printf("Device %d is not in TCC mode\n", i); continue; }`. This project runs on
+the default WDDM driver model, not TCC — so it is running outside NVIDIA's documented support envelope,
+not disproving it.
+
+What this codebase's testing does establish is that, *in practice*, it works there anyway: production IPC
+has been validated on Windows WDDM with CUDA 12.x across multiple format variants and teardown/reconnect
+cycles with no error 801. The "err 801" the migration brief cites arises on the `torch.multiprocessing`
+IPC path, not on raw `cudaIpcGetMemHandle` / `cudaIpcOpenMemHandle`. This is an engineering bet on
+observed behaviour outside the documented envelope, not a refutation of NVIDIA's stated support matrix —
+treat it as such: re-validate after driver/CUDA upgrades, and see the IPC capability probe
+(`CUDARuntimeAPI.check_ipc_capability()`) added to surface a diagnostic if this ever stops holding.
 
 Recording this as an ADR stops future explorers from spending time re-investigating a decision that has
 already been made with empirical evidence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "cuda-link"
-version = "1.12.1"
+version = "1.12.2"
 description = "Zero-copy GPU texture sharing via CUDA IPC for TouchDesigner integration"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/cuda_link/__init__.py
+++ b/src/cuda_link/__init__.py
@@ -24,7 +24,7 @@ from .shm_protocol import (
     publish_frame,
 )
 
-__version__ = "1.12.1"
+__version__ = "1.12.2"
 __all__ = [
     # Exporter API (v1.5.0+)
     "Exporter",

--- a/src/cuda_link/_cuda_adapters.py
+++ b/src/cuda_link/_cuda_adapters.py
@@ -325,9 +325,8 @@ class FakeCUDAAdapter:
         (tests the Exporter.open() failure path without a real GPU).
         """
         if self.fail_ipc_capability:
-            raise RuntimeError(
-                f"FakeCUDAAdapter: simulated cudaDevAttrIpcEventSupport=0 for device {device or self.device}"
-            )
+            resolved_device = device if device is not None else self.device
+            raise RuntimeError(f"FakeCUDAAdapter: simulated cudaDevAttrIpcEventSupport=0 for device {resolved_device}")
         return None
 
     # --- CUDA Graphs -------------------------------------------------------

--- a/src/cuda_link/_cuda_adapters.py
+++ b/src/cuda_link/_cuda_adapters.py
@@ -133,6 +133,8 @@ class FakeCUDAAdapter:
       - Set fail_on_malloc_count = N to make the Nth malloc() call raise.
       - Set fail_on_stream_create = True to make create_stream / _with_priority raise.
       - Set fail_on_event_create = True to make create_ipc_event raise.
+      - Set fail_ipc_capability = True to make check_ipc_capability() raise (simulates
+        cudaDevAttrIpcEventSupport == 0).
 
     Graph simulation:
       - graph_instantiate / graph_launch are no-ops (returns _FakeHandle).
@@ -152,6 +154,7 @@ class FakeCUDAAdapter:
         self.fail_on_malloc_count: int | None = None
         self.fail_on_stream_create: bool = False
         self.fail_on_event_create: bool = False
+        self.fail_ipc_capability: bool = False
         self._malloc_call_count = 0
 
         # Sticky-error simulation
@@ -313,6 +316,19 @@ class FakeCUDAAdapter:
     def check_sticky_error(self, context: str) -> None:
         if self._sticky_error != 0:
             raise RuntimeError(f"FakeCUDAAdapter: sticky error {self._sticky_error} after {context}")
+
+    def check_ipc_capability(self, device: int | None = None) -> str | None:
+        """Simulated IPC capability probe.
+
+        Returns None (nothing to report) by default. Set
+        ``fail_ipc_capability = True`` to simulate cudaDevAttrIpcEventSupport == 0
+        (tests the Exporter.open() failure path without a real GPU).
+        """
+        if self.fail_ipc_capability:
+            raise RuntimeError(
+                f"FakeCUDAAdapter: simulated cudaDevAttrIpcEventSupport=0 for device {device or self.device}"
+            )
+        return None
 
     # --- CUDA Graphs -------------------------------------------------------
 

--- a/src/cuda_link/_exporter_port.py
+++ b/src/cuda_link/_exporter_port.py
@@ -297,6 +297,15 @@ class CudaPort(Protocol):
         """Warn and raise if a sticky CUDA error is latched. No-op when all is well."""
         ...
 
+    def check_ipc_capability(self, device: int | None = None) -> str | None:
+        """Probe CUDA IPC support for this device; return a diagnostic string to log.
+
+        Raises only when the driver reports IPC as flatly unsupported (not merely
+        undocumented, e.g. Windows WDDM — which is this project's normal config).
+        See CUDARuntimeAPI.check_ipc_capability() in cuda_ipc_wrapper.py.
+        """
+        ...
+
     # --- CUDA Graphs (optional path; gated by ExportPolicy.use_graphs) ----
 
     def get_runtime_version(self) -> int:

--- a/src/cuda_link/cuda_ipc_wrapper.py
+++ b/src/cuda_link/cuda_ipc_wrapper.py
@@ -54,6 +54,7 @@ try:
     # In classic mode the sibling CUDARuntimeTypes Text DAT is already in sys.modules.
     from CUDARuntimeTypes import (  # type: ignore[no-redef]  # noqa: E402
         CUDA_DEV_ATTR_IPC_EVENT_SUPPORT,
+        CUDART_IPC_EVENT_SUPPORT_MIN_VERSION,
         HOST_ALLOC_PORTABLE,
         IPC_MEM_LAZY_ENABLE_PEER_ACCESS,
         CUDAError,
@@ -75,6 +76,7 @@ except (ImportError, ModuleNotFoundError):
     # (e.g. imported before the bootstrap runs, or in a standalone test environment).
     from cuda_link.cuda_runtime_types import (  # noqa: E402
         CUDA_DEV_ATTR_IPC_EVENT_SUPPORT,
+        CUDART_IPC_EVENT_SUPPORT_MIN_VERSION,
         HOST_ALLOC_PORTABLE,
         IPC_MEM_LAZY_ENABLE_PEER_ACCESS,
         CUDAError,
@@ -248,7 +250,7 @@ class CUDARuntimeAPI(CUDAGraphsMixin):
             else ""
         )
         raise CudaLinkError(
-            "Could not load CUDA runtime. Please ensure CUDA 12.x or 13.x is installed.\n"
+            "Could not load CUDA runtime. Please ensure CUDA 11.x, 12.x, or 13.x is installed.\n"
             f"Tried paths: {dll_paths}\n"
             f"Tried names: {dll_names}"
             f"{err_detail}{hint_126}"
@@ -1421,20 +1423,51 @@ class CUDARuntimeAPI(CUDAGraphsMixin):
         unambiguous "this cannot work here" signal, as opposed to the
         undocumented-but-working WDDM configuration.
 
+        This probe is purely diagnostic and must never abort exporter initialization
+        on its own: cudaDevAttrIpcEventSupport (125) is a CUDA 12.0+ attribute (the
+        loader also accepts an 11.x cudart — see _load_cuda_runtime(), and TouchDesigner
+        ships cudart64_110.dll), so the query is version-gated, and any unexpected query
+        failure degrades to a logged note rather than propagating.
+
         Args:
             device: GPU device index. Defaults to self.device.
 
         Returns:
-            A one-line diagnostic to log (present on Windows, to give context if a
-            later cudaIpc* call fails with error 400/801), or None if there is
-            nothing noteworthy to report (e.g. non-Windows).
+            A one-line diagnostic to log (present on Windows, or when the query was
+            skipped/failed, to give context if a later cudaIpc* call fails with error
+            400/801), or None if there is nothing noteworthy to report (e.g. non-Windows
+            with a successful query).
 
         Raises:
             CudaIpcError: If cudaDevAttrIpcEventSupport reports 0 for this device.
         """
         if device is None:
             device = self.device
-        support = self.get_device_attribute(CUDA_DEV_ATTR_IPC_EVENT_SUPPORT, device)
+
+        try:
+            runtime_version = self.get_runtime_version()
+        except (RuntimeError, OSError) as exc:
+            _logger.debug("check_ipc_capability: get_runtime_version() failed: %s", exc)
+            runtime_version = 0
+
+        if runtime_version < CUDART_IPC_EVENT_SUPPORT_MIN_VERSION:
+            return (
+                f"CUDA IPC capability probe skipped: runtime version {runtime_version} predates "
+                f"cudaDevAttrIpcEventSupport (added in CUDA {CUDART_IPC_EVENT_SUPPORT_MIN_VERSION}). "
+                "If IPC calls fail with error 400 (cudaErrorInvalidResourceHandle) or 801 "
+                "(cudaErrorNotSupported), this older runtime is a plausible cause."
+            )
+
+        try:
+            support = self.get_device_attribute(CUDA_DEV_ATTR_IPC_EVENT_SUPPORT, device)
+        except CudaIpcError as exc:
+            _logger.debug("check_ipc_capability: cudaDevAttrIpcEventSupport query failed: %s", exc)
+            return (
+                f"CUDA IPC capability probe: could not query cudaDevAttrIpcEventSupport for "
+                f"device {device} on runtime {runtime_version} ({exc}). Continuing without this "
+                "diagnostic; if IPC calls fail with error 400 or 801, this is a plausible cause."
+            )
+
         if support == 0:
             raise CudaIpcError(
                 f"CUDA device {device} reports cudaDevAttrIpcEventSupport=0 — this GPU/driver "

--- a/src/cuda_link/cuda_ipc_wrapper.py
+++ b/src/cuda_link/cuda_ipc_wrapper.py
@@ -53,6 +53,7 @@ try:
     # cuda_link.cuda_runtime_types before this module is imported, so this succeeds.
     # In classic mode the sibling CUDARuntimeTypes Text DAT is already in sys.modules.
     from CUDARuntimeTypes import (  # type: ignore[no-redef]  # noqa: E402
+        CUDA_DEV_ATTR_IPC_EVENT_SUPPORT,
         HOST_ALLOC_PORTABLE,
         IPC_MEM_LAZY_ENABLE_PEER_ACCESS,
         CUDAError,
@@ -73,6 +74,7 @@ except (ImportError, ModuleNotFoundError):
     # Fallback: pure package context where CUDARuntimeTypes is not yet in sys.modules
     # (e.g. imported before the bootstrap runs, or in a standalone test environment).
     from cuda_link.cuda_runtime_types import (  # noqa: E402
+        CUDA_DEV_ATTR_IPC_EVENT_SUPPORT,
         HOST_ALLOC_PORTABLE,
         IPC_MEM_LAZY_ENABLE_PEER_ACCESS,
         CUDAError,
@@ -141,6 +143,7 @@ class CUDARuntimeAPI(CUDAGraphsMixin):
         self._retained_ctx_stack: list[int] = []
         self.cudart = self._load_cuda_runtime()
         self._setup_function_signatures()
+        self._check_pointer_attributes_abi()
         # Load the driver API (nvcuda.dll) for primary-context save/restore in set_device().
         # Must follow _setup_function_signatures() so cudart argtypes are already wired.
         self._drv: ctypes.CDLL | None = self._load_driver_api()
@@ -280,6 +283,42 @@ class CUDARuntimeAPI(CUDAGraphsMixin):
                 print(f"[CUDAIPC] cudart loaded: {buf.value}", flush=True)
         except OSError as e:
             print(f"[CUDAIPC] cudart loaded: {hint} (could not resolve path: {e})", flush=True)
+
+    def _check_pointer_attributes_abi(self) -> None:
+        """Log which cudaPointerAttributes layout the loaded runtime implies.
+
+        cudaPointerAttributes changed shape between CUDA 12.x (24 bytes) and CUDA 13.x
+        (56 bytes — added ``long reserved[8]``); see the ABI note on the struct
+        definition in cuda_runtime_types.py. This binding's ctypes struct is sized to
+        the newest layout known at the time this code was written (13.x). The
+        `_abi_guard()` checks in that module only validate the ctypes definition
+        against itself — they cannot detect a future runtime introducing yet another
+        layout change. This method closes that blind spot by comparing the *actual
+        loaded runtime's* version against the newest layout this binding knows about,
+        and warns instead of silently risking a truncated/misaligned read.
+
+        Must run after _setup_function_signatures() (cudaRuntimeGetVersion argtypes).
+        """
+        version = self.get_runtime_version()
+        major = version // 1000
+        if major >= 14:
+            _logger.warning(
+                "Loaded CUDA runtime version %d (major %d.x) is newer than any "
+                "cudaPointerAttributes layout this binding has verified (checked "
+                "through CUDA 13.x: 56-byte struct with reserved[8]). If NVIDIA changed "
+                "the struct again in CUDA %d.x, pointer_get_attributes() may read a "
+                "stale/misaligned result. Check driver_types.h for this runtime and "
+                "update cuda_runtime_types.cudaPointerAttributes if the layout changed.",
+                version,
+                major,
+                major,
+            )
+        else:
+            _logger.debug(
+                "Loaded CUDA runtime version %d implies cudaPointerAttributes layout: %s",
+                version,
+                "56 bytes (reserved[8], CUDA 13.x+)" if major >= 13 else "24 bytes (legacy, pre-13.x)",
+            )
 
     def _load_driver_api(self) -> ctypes.CDLL | None:
         """Load nvcuda.dll (CUDA Driver API) and bind the 5 context-management symbols.
@@ -484,7 +523,9 @@ class CUDARuntimeAPI(CUDAGraphsMixin):
         self.cudart.cudaHostAlloc.restype = c_int
 
         # cudaDeviceGetAttribute(int* value, cudaDeviceAttr attr, int device)
-        # Used to query cudaDevAttrAsyncEngineCount (attr=4) — how many DMA copy engines exist.
+        # Used to query e.g. cudaDevAttrAsyncEngineCount (attr=40, CUDA_DEV_ATTR_ASYNC_ENGINE_COUNT)
+        # — how many DMA copy engines exist — and cudaDevAttrIpcEventSupport (attr=125,
+        # CUDA_DEV_ATTR_IPC_EVENT_SUPPORT) — see check_ipc_capability() below.
         self.cudart.cudaDeviceGetAttribute.argtypes = [POINTER(c_int), c_int, c_int]
         self.cudart.cudaDeviceGetAttribute.restype = c_int
 
@@ -1280,6 +1321,13 @@ class CUDARuntimeAPI(CUDAGraphsMixin):
 
         Raises:
             RuntimeError: If query fails (e.g., unregistered host pointer passed)
+
+        Note:
+            The out-param buffer is deliberately sized to the largest known
+            cudaPointerAttributes layout (CUDA 13.x's 56-byte struct — see the
+            ABI note on the class) rather than the loaded cudart's actual layout,
+            since this wrapper does not branch on runtime version here. An older
+            cudart simply writes fewer bytes into a larger buffer, which is safe.
         """
         attrs = cudaPointerAttributes()
         self.cudart.cudaPointerGetAttributes(byref(attrs), c_void_p(ptr))
@@ -1338,8 +1386,9 @@ class CUDARuntimeAPI(CUDAGraphsMixin):
     def get_device_attribute(self, attr: int, device: int | None = None) -> int:
         """Query a cudaDeviceAttr value for a given device.
 
-        Common attrs:
-            cudaDevAttrAsyncEngineCount = 4 — number of DMA copy engines
+        Common attrs (see cuda_runtime_types.py):
+            CUDA_DEV_ATTR_ASYNC_ENGINE_COUNT (40) — number of DMA copy engines
+            CUDA_DEV_ATTR_IPC_EVENT_SUPPORT (125) — 0 if CUDA IPC events are unsupported
 
         Args:
             attr:   cudaDeviceAttr integer constant.
@@ -1356,6 +1405,55 @@ class CUDARuntimeAPI(CUDAGraphsMixin):
         value = c_int()
         self.cudart.cudaDeviceGetAttribute(byref(value), c_int(attr), c_int(device))
         return value.value
+
+    def check_ipc_capability(self, device: int | None = None) -> str | None:
+        """Probe whether this device/driver combination supports CUDA IPC.
+
+        NVIDIA documents the legacy ``cudaIpc*`` API as Linux-only, and on Windows
+        as supported only under the TCC driver model (see the ``simpleIPC`` sample,
+        which gates on ``prop.tccDriver``). cuda-link runs it on Windows WDDM, which
+        works in practice — see docs/adr/0004-legacy-cuda-ipc-over-vmm.md — but is
+        outside NVIDIA's documented support envelope. This method does NOT fail on
+        WDDM; that is this project's normal, supported-by-evidence configuration.
+
+        It raises only when the driver reports CUDA IPC events as flatly
+        unsupported for this device (cudaDevAttrIpcEventSupport == 0) — an
+        unambiguous "this cannot work here" signal, as opposed to the
+        undocumented-but-working WDDM configuration.
+
+        Args:
+            device: GPU device index. Defaults to self.device.
+
+        Returns:
+            A one-line diagnostic to log (present on Windows, to give context if a
+            later cudaIpc* call fails with error 400/801), or None if there is
+            nothing noteworthy to report (e.g. non-Windows).
+
+        Raises:
+            CudaIpcError: If cudaDevAttrIpcEventSupport reports 0 for this device.
+        """
+        if device is None:
+            device = self.device
+        support = self.get_device_attribute(CUDA_DEV_ATTR_IPC_EVENT_SUPPORT, device)
+        if support == 0:
+            raise CudaIpcError(
+                f"CUDA device {device} reports cudaDevAttrIpcEventSupport=0 — this GPU/driver "
+                "combination does not support CUDA IPC events, so cuda-link cannot function on "
+                "it. NVIDIA documents legacy CUDA IPC as Linux-only, or Windows-TCC-only; this "
+                "project's Windows-WDDM support is an undocumented-but-validated configuration "
+                "(see docs/adr/0004-legacy-cuda-ipc-over-vmm.md) — if you are on WDDM and still "
+                "see this, the failure is specific to this device/driver, not the OS mode."
+            )
+        if os.name == "nt":
+            return (
+                f"CUDA IPC capability probe: device {device} reports IPC event support. Running "
+                "on Windows — NVIDIA documents legacy CUDA IPC as Linux-only / Windows-TCC-only; "
+                "cuda-link relies on Windows-WDDM behaviour that works in practice but is outside "
+                "NVIDIA's documented support envelope (see docs/adr/0004-legacy-cuda-ipc-over-vmm.md). "
+                "If IPC calls fail with error 400 (cudaErrorInvalidResourceHandle) or 801 "
+                "(cudaErrorNotSupported), this undocumented-support gap is the most likely cause."
+            )
+        return None
 
 
 # Global singleton instance (lazy initialization)

--- a/src/cuda_link/cuda_runtime_types.py
+++ b/src/cuda_link/cuda_runtime_types.py
@@ -105,6 +105,12 @@ class cudaPointerAttributes(ctypes.Structure):
     which is safe, whereas a 24-byte buffer handed to a 13.x cudart is an
     undersized out-parameter (out-of-bounds write risk). The four original
     fields keep their offsets, so .type/.device access is unaffected either way.
+
+    Uses `c_int32` (not `ctypes.c_long`) for `reserved`: this struct models the
+    target Windows/MSVC cudart ABI, where `long` is always 4 bytes, but
+    `ctypes.c_long` tracks the *host* platform's C `long` — 8 bytes on Linux/LP64
+    (e.g. the CI runner running this file's no-GPU tests). `c_long * 8` would
+    silently produce an 88-byte struct there instead of 56.
     """
 
     _fields_ = [
@@ -112,7 +118,7 @@ class cudaPointerAttributes(ctypes.Structure):
         ("device", c_int),  # GPU device index owning this allocation
         ("devicePointer", c_void_p),
         ("hostPointer", c_void_p),
-        ("reserved", ctypes.c_long * 8),  # CUDA 13.x+ only; unused, must be zero
+        ("reserved", ctypes.c_int32 * 8),  # CUDA 13.x+ only; unused, must be zero
     ]
 
 

--- a/src/cuda_link/cuda_runtime_types.py
+++ b/src/cuda_link/cuda_runtime_types.py
@@ -24,6 +24,11 @@ CUDAGraphNode_t = c_uint64  # cudaGraphNode_t opaque pointer (CUDA 10.0+)
 # cudaGraphExecEventWaitNodeSetEvent are all CUDA 11.4+ (version integer 11040).
 CUDART_GRAPHS_MIN_VERSION = 11040
 
+# Minimum cudart version that defines cudaDevAttrIpcEventSupport (125).
+# CUDA 11.x tops out at 121 (cudaDevAttrDeferredMappingCudaArraySupported); querying 125
+# against an 11.x runtime returns cudaErrorInvalidValue.
+CUDART_IPC_EVENT_SUPPORT_MIN_VERSION = 12000
+
 # --- CUDA Graph parameter structs ---
 
 

--- a/src/cuda_link/cuda_runtime_types.py
+++ b/src/cuda_link/cuda_runtime_types.py
@@ -95,6 +95,16 @@ class cudaPointerAttributes(ctypes.Structure):
 
     .type values: 0=unregistered, 1=host, 2=device, 3=managed
     .device: GPU index that owns the allocation
+
+    ABI note: CUDA 13.x's driver_types.h added a fifth field, `long reserved[8]`
+    ("Must be zero"), that CUDA 12.x and earlier do not have. Under MSVC x64
+    (`long` = 4 bytes) that grows the struct from 24 to 56 bytes. Since this
+    binding's loader (_load_cuda_runtime() in cuda_ipc_wrapper.py) may attach to
+    either a 12.x or 13.x cudart at runtime, the buffer is always sized to the
+    larger (13.x) layout: an older cudart simply writes fewer bytes into it,
+    which is safe, whereas a 24-byte buffer handed to a 13.x cudart is an
+    undersized out-parameter (out-of-bounds write risk). The four original
+    fields keep their offsets, so .type/.device access is unaffected either way.
     """
 
     _fields_ = [
@@ -102,6 +112,7 @@ class cudaPointerAttributes(ctypes.Structure):
         ("device", c_int),  # GPU device index owning this allocation
         ("devicePointer", c_void_p),
         ("hostPointer", c_void_p),
+        ("reserved", ctypes.c_long * 8),  # CUDA 13.x+ only; unused, must be zero
     ]
 
 
@@ -117,9 +128,17 @@ def _abi_guard(actual: int, expected: int, name: str) -> None:
 
 _abi_guard(ctypes.sizeof(cudaIpcMemHandle_t), 64, "cudaIpcMemHandle_t")
 _abi_guard(ctypes.sizeof(cudaIpcEventHandle_t), 64, "cudaIpcEventHandle_t")
-_abi_guard(ctypes.sizeof(cudaPointerAttributes), 24, "cudaPointerAttributes")
+_abi_guard(ctypes.sizeof(cudaPointerAttributes), 56, "cudaPointerAttributes")
+# Note on what these guards do and don't prove: they only check that THIS module's
+# ctypes _fields_ produce the byte size we intend (a self-consistency check against
+# drift in this file). They cannot detect a struct layout mismatch against whichever
+# cudart DLL is actually loaded at runtime — see the runtime-version check in
+# CUDARuntimeAPI._load_cuda_runtime() / check_ipc_capability() in cuda_ipc_wrapper.py
+# for the runtime-vs-binding side of that problem.
 # Graph param struct ABI guards — cudaMemcpy3DParms is the largest and most alignment-sensitive.
-# All four values were verified against Python ctypes on a 64-bit Windows host (sizeof c_size_t=8).
+# All values were verified against the CUDA 12.8 and 13.3 headers on a 64-bit Windows host
+# (sizeof c_size_t=8); cudaPos/cudaPitchedPtr/cudaExtent/cudaMemcpy3DParms are unchanged
+# between those two toolkit versions.
 _abi_guard(ctypes.sizeof(cudaPos), 24, "cudaPos")
 _abi_guard(ctypes.sizeof(cudaPitchedPtr), 32, "cudaPitchedPtr")
 _abi_guard(ctypes.sizeof(cudaExtent), 24, "cudaExtent")
@@ -229,3 +248,11 @@ IPC_MEM_LAZY_ENABLE_PEER_ACCESS: int = 1
 
 # cudaHostAllocPortable — pinned allocation visible from any CUDA context in the process.
 HOST_ALLOC_PORTABLE: int = 0x01
+
+# --- cudaDeviceAttr values used with get_device_attribute() ---
+# NOTE: cudaDevAttrAsyncEngineCount was previously documented (and used in tests) as 4.
+# Per CUDA 12.8/13.3 driver_types.h it is 40; attribute 4 is cudaDevAttrMaxBlockDimZ, an
+# unrelated value that a caller using the old constant would silently receive instead.
+CUDA_DEV_ATTR_ASYNC_ENGINE_COUNT: int = 40  # cudaDevAttrAsyncEngineCount — DMA copy engine count
+CUDA_DEV_ATTR_IPC_EVENT_SUPPORT: int = 125  # cudaDevAttrIpcEventSupport — 0 if this device/driver
+# cannot support CUDA IPC events (used by check_ipc_capability() in cuda_ipc_wrapper.py)

--- a/src/cuda_link/exporter.py
+++ b/src/cuda_link/exporter.py
@@ -251,6 +251,15 @@ class Exporter:
             )
         logger.info("Loaded CUDA runtime on device %d", actual_device)
 
+        # Raises only when the driver reports CUDA IPC as flatly unsupported on this
+        # device; Windows WDDM (this project's normal, undocumented-but-validated
+        # configuration — see docs/adr/0004-legacy-cuda-ipc-over-vmm.md) returns a
+        # message here rather than raising. Logged before any IPC handle is minted so
+        # a later error 400/801 has this context available.
+        ipc_capability_note = self._cuda.check_ipc_capability()
+        if ipc_capability_note:
+            logger.info(ipc_capability_note)
+
         hws_mode = _read_hws_mode()
         logger.info("WDDM HwSchMode: %s (0=software, 2=hardware/GPU-P, unknown=non-Windows)", hws_mode)
         if hws_mode == "0":

--- a/td_exporter/CUDAAdapters.py
+++ b/td_exporter/CUDAAdapters.py
@@ -325,9 +325,8 @@ class FakeCUDAAdapter:
         (tests the Exporter.open() failure path without a real GPU).
         """
         if self.fail_ipc_capability:
-            raise RuntimeError(
-                f"FakeCUDAAdapter: simulated cudaDevAttrIpcEventSupport=0 for device {device or self.device}"
-            )
+            resolved_device = device if device is not None else self.device
+            raise RuntimeError(f"FakeCUDAAdapter: simulated cudaDevAttrIpcEventSupport=0 for device {resolved_device}")
         return None
 
     # --- CUDA Graphs -------------------------------------------------------

--- a/td_exporter/CUDAAdapters.py
+++ b/td_exporter/CUDAAdapters.py
@@ -133,6 +133,8 @@ class FakeCUDAAdapter:
       - Set fail_on_malloc_count = N to make the Nth malloc() call raise.
       - Set fail_on_stream_create = True to make create_stream / _with_priority raise.
       - Set fail_on_event_create = True to make create_ipc_event raise.
+      - Set fail_ipc_capability = True to make check_ipc_capability() raise (simulates
+        cudaDevAttrIpcEventSupport == 0).
 
     Graph simulation:
       - graph_instantiate / graph_launch are no-ops (returns _FakeHandle).
@@ -152,6 +154,7 @@ class FakeCUDAAdapter:
         self.fail_on_malloc_count: int | None = None
         self.fail_on_stream_create: bool = False
         self.fail_on_event_create: bool = False
+        self.fail_ipc_capability: bool = False
         self._malloc_call_count = 0
 
         # Sticky-error simulation
@@ -313,6 +316,19 @@ class FakeCUDAAdapter:
     def check_sticky_error(self, context: str) -> None:
         if self._sticky_error != 0:
             raise RuntimeError(f"FakeCUDAAdapter: sticky error {self._sticky_error} after {context}")
+
+    def check_ipc_capability(self, device: int | None = None) -> str | None:
+        """Simulated IPC capability probe.
+
+        Returns None (nothing to report) by default. Set
+        ``fail_ipc_capability = True`` to simulate cudaDevAttrIpcEventSupport == 0
+        (tests the Exporter.open() failure path without a real GPU).
+        """
+        if self.fail_ipc_capability:
+            raise RuntimeError(
+                f"FakeCUDAAdapter: simulated cudaDevAttrIpcEventSupport=0 for device {device or self.device}"
+            )
+        return None
 
     # --- CUDA Graphs -------------------------------------------------------
 

--- a/td_exporter/CUDAIPCWrapper.py
+++ b/td_exporter/CUDAIPCWrapper.py
@@ -54,6 +54,7 @@ try:
     # In classic mode the sibling CUDARuntimeTypes Text DAT is already in sys.modules.
     from CUDARuntimeTypes import (  # type: ignore[no-redef]  # noqa: E402
         CUDA_DEV_ATTR_IPC_EVENT_SUPPORT,
+        CUDART_IPC_EVENT_SUPPORT_MIN_VERSION,
         HOST_ALLOC_PORTABLE,
         IPC_MEM_LAZY_ENABLE_PEER_ACCESS,
         CUDAError,
@@ -75,6 +76,7 @@ except (ImportError, ModuleNotFoundError):
     # (e.g. imported before the bootstrap runs, or in a standalone test environment).
     from cuda_link.cuda_runtime_types import (  # noqa: E402
         CUDA_DEV_ATTR_IPC_EVENT_SUPPORT,
+        CUDART_IPC_EVENT_SUPPORT_MIN_VERSION,
         HOST_ALLOC_PORTABLE,
         IPC_MEM_LAZY_ENABLE_PEER_ACCESS,
         CUDAError,
@@ -248,7 +250,7 @@ class CUDARuntimeAPI(CUDAGraphsMixin):
             else ""
         )
         raise CudaLinkError(
-            "Could not load CUDA runtime. Please ensure CUDA 12.x or 13.x is installed.\n"
+            "Could not load CUDA runtime. Please ensure CUDA 11.x, 12.x, or 13.x is installed.\n"
             f"Tried paths: {dll_paths}\n"
             f"Tried names: {dll_names}"
             f"{err_detail}{hint_126}"
@@ -1421,20 +1423,51 @@ class CUDARuntimeAPI(CUDAGraphsMixin):
         unambiguous "this cannot work here" signal, as opposed to the
         undocumented-but-working WDDM configuration.
 
+        This probe is purely diagnostic and must never abort exporter initialization
+        on its own: cudaDevAttrIpcEventSupport (125) is a CUDA 12.0+ attribute (the
+        loader also accepts an 11.x cudart — see _load_cuda_runtime(), and TouchDesigner
+        ships cudart64_110.dll), so the query is version-gated, and any unexpected query
+        failure degrades to a logged note rather than propagating.
+
         Args:
             device: GPU device index. Defaults to self.device.
 
         Returns:
-            A one-line diagnostic to log (present on Windows, to give context if a
-            later cudaIpc* call fails with error 400/801), or None if there is
-            nothing noteworthy to report (e.g. non-Windows).
+            A one-line diagnostic to log (present on Windows, or when the query was
+            skipped/failed, to give context if a later cudaIpc* call fails with error
+            400/801), or None if there is nothing noteworthy to report (e.g. non-Windows
+            with a successful query).
 
         Raises:
             CudaIpcError: If cudaDevAttrIpcEventSupport reports 0 for this device.
         """
         if device is None:
             device = self.device
-        support = self.get_device_attribute(CUDA_DEV_ATTR_IPC_EVENT_SUPPORT, device)
+
+        try:
+            runtime_version = self.get_runtime_version()
+        except (RuntimeError, OSError) as exc:
+            _logger.debug("check_ipc_capability: get_runtime_version() failed: %s", exc)
+            runtime_version = 0
+
+        if runtime_version < CUDART_IPC_EVENT_SUPPORT_MIN_VERSION:
+            return (
+                f"CUDA IPC capability probe skipped: runtime version {runtime_version} predates "
+                f"cudaDevAttrIpcEventSupport (added in CUDA {CUDART_IPC_EVENT_SUPPORT_MIN_VERSION}). "
+                "If IPC calls fail with error 400 (cudaErrorInvalidResourceHandle) or 801 "
+                "(cudaErrorNotSupported), this older runtime is a plausible cause."
+            )
+
+        try:
+            support = self.get_device_attribute(CUDA_DEV_ATTR_IPC_EVENT_SUPPORT, device)
+        except CudaIpcError as exc:
+            _logger.debug("check_ipc_capability: cudaDevAttrIpcEventSupport query failed: %s", exc)
+            return (
+                f"CUDA IPC capability probe: could not query cudaDevAttrIpcEventSupport for "
+                f"device {device} on runtime {runtime_version} ({exc}). Continuing without this "
+                "diagnostic; if IPC calls fail with error 400 or 801, this is a plausible cause."
+            )
+
         if support == 0:
             raise CudaIpcError(
                 f"CUDA device {device} reports cudaDevAttrIpcEventSupport=0 — this GPU/driver "

--- a/td_exporter/CUDAIPCWrapper.py
+++ b/td_exporter/CUDAIPCWrapper.py
@@ -53,6 +53,7 @@ try:
     # cuda_link.cuda_runtime_types before this module is imported, so this succeeds.
     # In classic mode the sibling CUDARuntimeTypes Text DAT is already in sys.modules.
     from CUDARuntimeTypes import (  # type: ignore[no-redef]  # noqa: E402
+        CUDA_DEV_ATTR_IPC_EVENT_SUPPORT,
         HOST_ALLOC_PORTABLE,
         IPC_MEM_LAZY_ENABLE_PEER_ACCESS,
         CUDAError,
@@ -73,6 +74,7 @@ except (ImportError, ModuleNotFoundError):
     # Fallback: pure package context where CUDARuntimeTypes is not yet in sys.modules
     # (e.g. imported before the bootstrap runs, or in a standalone test environment).
     from cuda_link.cuda_runtime_types import (  # noqa: E402
+        CUDA_DEV_ATTR_IPC_EVENT_SUPPORT,
         HOST_ALLOC_PORTABLE,
         IPC_MEM_LAZY_ENABLE_PEER_ACCESS,
         CUDAError,
@@ -141,6 +143,7 @@ class CUDARuntimeAPI(CUDAGraphsMixin):
         self._retained_ctx_stack: list[int] = []
         self.cudart = self._load_cuda_runtime()
         self._setup_function_signatures()
+        self._check_pointer_attributes_abi()
         # Load the driver API (nvcuda.dll) for primary-context save/restore in set_device().
         # Must follow _setup_function_signatures() so cudart argtypes are already wired.
         self._drv: ctypes.CDLL | None = self._load_driver_api()
@@ -280,6 +283,42 @@ class CUDARuntimeAPI(CUDAGraphsMixin):
                 print(f"[CUDAIPC] cudart loaded: {buf.value}", flush=True)
         except OSError as e:
             print(f"[CUDAIPC] cudart loaded: {hint} (could not resolve path: {e})", flush=True)
+
+    def _check_pointer_attributes_abi(self) -> None:
+        """Log which cudaPointerAttributes layout the loaded runtime implies.
+
+        cudaPointerAttributes changed shape between CUDA 12.x (24 bytes) and CUDA 13.x
+        (56 bytes — added ``long reserved[8]``); see the ABI note on the struct
+        definition in cuda_runtime_types.py. This binding's ctypes struct is sized to
+        the newest layout known at the time this code was written (13.x). The
+        `_abi_guard()` checks in that module only validate the ctypes definition
+        against itself — they cannot detect a future runtime introducing yet another
+        layout change. This method closes that blind spot by comparing the *actual
+        loaded runtime's* version against the newest layout this binding knows about,
+        and warns instead of silently risking a truncated/misaligned read.
+
+        Must run after _setup_function_signatures() (cudaRuntimeGetVersion argtypes).
+        """
+        version = self.get_runtime_version()
+        major = version // 1000
+        if major >= 14:
+            _logger.warning(
+                "Loaded CUDA runtime version %d (major %d.x) is newer than any "
+                "cudaPointerAttributes layout this binding has verified (checked "
+                "through CUDA 13.x: 56-byte struct with reserved[8]). If NVIDIA changed "
+                "the struct again in CUDA %d.x, pointer_get_attributes() may read a "
+                "stale/misaligned result. Check driver_types.h for this runtime and "
+                "update cuda_runtime_types.cudaPointerAttributes if the layout changed.",
+                version,
+                major,
+                major,
+            )
+        else:
+            _logger.debug(
+                "Loaded CUDA runtime version %d implies cudaPointerAttributes layout: %s",
+                version,
+                "56 bytes (reserved[8], CUDA 13.x+)" if major >= 13 else "24 bytes (legacy, pre-13.x)",
+            )
 
     def _load_driver_api(self) -> ctypes.CDLL | None:
         """Load nvcuda.dll (CUDA Driver API) and bind the 5 context-management symbols.
@@ -484,7 +523,9 @@ class CUDARuntimeAPI(CUDAGraphsMixin):
         self.cudart.cudaHostAlloc.restype = c_int
 
         # cudaDeviceGetAttribute(int* value, cudaDeviceAttr attr, int device)
-        # Used to query cudaDevAttrAsyncEngineCount (attr=4) — how many DMA copy engines exist.
+        # Used to query e.g. cudaDevAttrAsyncEngineCount (attr=40, CUDA_DEV_ATTR_ASYNC_ENGINE_COUNT)
+        # — how many DMA copy engines exist — and cudaDevAttrIpcEventSupport (attr=125,
+        # CUDA_DEV_ATTR_IPC_EVENT_SUPPORT) — see check_ipc_capability() below.
         self.cudart.cudaDeviceGetAttribute.argtypes = [POINTER(c_int), c_int, c_int]
         self.cudart.cudaDeviceGetAttribute.restype = c_int
 
@@ -1280,6 +1321,13 @@ class CUDARuntimeAPI(CUDAGraphsMixin):
 
         Raises:
             RuntimeError: If query fails (e.g., unregistered host pointer passed)
+
+        Note:
+            The out-param buffer is deliberately sized to the largest known
+            cudaPointerAttributes layout (CUDA 13.x's 56-byte struct — see the
+            ABI note on the class) rather than the loaded cudart's actual layout,
+            since this wrapper does not branch on runtime version here. An older
+            cudart simply writes fewer bytes into a larger buffer, which is safe.
         """
         attrs = cudaPointerAttributes()
         self.cudart.cudaPointerGetAttributes(byref(attrs), c_void_p(ptr))
@@ -1338,8 +1386,9 @@ class CUDARuntimeAPI(CUDAGraphsMixin):
     def get_device_attribute(self, attr: int, device: int | None = None) -> int:
         """Query a cudaDeviceAttr value for a given device.
 
-        Common attrs:
-            cudaDevAttrAsyncEngineCount = 4 — number of DMA copy engines
+        Common attrs (see cuda_runtime_types.py):
+            CUDA_DEV_ATTR_ASYNC_ENGINE_COUNT (40) — number of DMA copy engines
+            CUDA_DEV_ATTR_IPC_EVENT_SUPPORT (125) — 0 if CUDA IPC events are unsupported
 
         Args:
             attr:   cudaDeviceAttr integer constant.
@@ -1356,6 +1405,55 @@ class CUDARuntimeAPI(CUDAGraphsMixin):
         value = c_int()
         self.cudart.cudaDeviceGetAttribute(byref(value), c_int(attr), c_int(device))
         return value.value
+
+    def check_ipc_capability(self, device: int | None = None) -> str | None:
+        """Probe whether this device/driver combination supports CUDA IPC.
+
+        NVIDIA documents the legacy ``cudaIpc*`` API as Linux-only, and on Windows
+        as supported only under the TCC driver model (see the ``simpleIPC`` sample,
+        which gates on ``prop.tccDriver``). cuda-link runs it on Windows WDDM, which
+        works in practice — see docs/adr/0004-legacy-cuda-ipc-over-vmm.md — but is
+        outside NVIDIA's documented support envelope. This method does NOT fail on
+        WDDM; that is this project's normal, supported-by-evidence configuration.
+
+        It raises only when the driver reports CUDA IPC events as flatly
+        unsupported for this device (cudaDevAttrIpcEventSupport == 0) — an
+        unambiguous "this cannot work here" signal, as opposed to the
+        undocumented-but-working WDDM configuration.
+
+        Args:
+            device: GPU device index. Defaults to self.device.
+
+        Returns:
+            A one-line diagnostic to log (present on Windows, to give context if a
+            later cudaIpc* call fails with error 400/801), or None if there is
+            nothing noteworthy to report (e.g. non-Windows).
+
+        Raises:
+            CudaIpcError: If cudaDevAttrIpcEventSupport reports 0 for this device.
+        """
+        if device is None:
+            device = self.device
+        support = self.get_device_attribute(CUDA_DEV_ATTR_IPC_EVENT_SUPPORT, device)
+        if support == 0:
+            raise CudaIpcError(
+                f"CUDA device {device} reports cudaDevAttrIpcEventSupport=0 — this GPU/driver "
+                "combination does not support CUDA IPC events, so cuda-link cannot function on "
+                "it. NVIDIA documents legacy CUDA IPC as Linux-only, or Windows-TCC-only; this "
+                "project's Windows-WDDM support is an undocumented-but-validated configuration "
+                "(see docs/adr/0004-legacy-cuda-ipc-over-vmm.md) — if you are on WDDM and still "
+                "see this, the failure is specific to this device/driver, not the OS mode."
+            )
+        if os.name == "nt":
+            return (
+                f"CUDA IPC capability probe: device {device} reports IPC event support. Running "
+                "on Windows — NVIDIA documents legacy CUDA IPC as Linux-only / Windows-TCC-only; "
+                "cuda-link relies on Windows-WDDM behaviour that works in practice but is outside "
+                "NVIDIA's documented support envelope (see docs/adr/0004-legacy-cuda-ipc-over-vmm.md). "
+                "If IPC calls fail with error 400 (cudaErrorInvalidResourceHandle) or 801 "
+                "(cudaErrorNotSupported), this undocumented-support gap is the most likely cause."
+            )
+        return None
 
 
 # Global singleton instance (lazy initialization)

--- a/td_exporter/CUDALinkBootstrap.py
+++ b/td_exporter/CUDALinkBootstrap.py
@@ -17,13 +17,13 @@ Library mode (this module's purpose):
     Set CUDALINK_LIB_PATH to a folder created by:
         pip install --target <folder> "dist/cuda_link-<ver>-py3-none-any.whl"
     This module injects that folder onto sys.path, imports the cuda_link package,
-    and registers all 14 mirror module names in sys.modules as aliases to the
-    installed submodules.  The 14 mirror Text DATs (Env, SHMProtocol, Exporter, …)
+    and registers all 15 mirror module names in sys.modules as aliases to the
+    installed submodules.  The 15 mirror Text DATs (Env, SHMProtocol, Exporter, …)
     can then be removed from the COMP.
 
 Fallback / classic mode:
     If CUDALINK_LIB_PATH is not set or cuda_link is not importable, this module
-    no-ops and prints a notice.  All 14 mirror Text DATs must be present in the COMP
+    no-ops and prints a notice.  All 15 mirror Text DATs must be present in the COMP
     as before (the original "paste all DATs" deployment story is fully preserved).
 
 Drift guard:

--- a/td_exporter/CUDARuntimeTypes.py
+++ b/td_exporter/CUDARuntimeTypes.py
@@ -105,6 +105,12 @@ class cudaPointerAttributes(ctypes.Structure):
     which is safe, whereas a 24-byte buffer handed to a 13.x cudart is an
     undersized out-parameter (out-of-bounds write risk). The four original
     fields keep their offsets, so .type/.device access is unaffected either way.
+
+    Uses `c_int32` (not `ctypes.c_long`) for `reserved`: this struct models the
+    target Windows/MSVC cudart ABI, where `long` is always 4 bytes, but
+    `ctypes.c_long` tracks the *host* platform's C `long` — 8 bytes on Linux/LP64
+    (e.g. the CI runner running this file's no-GPU tests). `c_long * 8` would
+    silently produce an 88-byte struct there instead of 56.
     """
 
     _fields_ = [
@@ -112,7 +118,7 @@ class cudaPointerAttributes(ctypes.Structure):
         ("device", c_int),  # GPU device index owning this allocation
         ("devicePointer", c_void_p),
         ("hostPointer", c_void_p),
-        ("reserved", ctypes.c_long * 8),  # CUDA 13.x+ only; unused, must be zero
+        ("reserved", ctypes.c_int32 * 8),  # CUDA 13.x+ only; unused, must be zero
     ]
 
 

--- a/td_exporter/CUDARuntimeTypes.py
+++ b/td_exporter/CUDARuntimeTypes.py
@@ -24,6 +24,11 @@ CUDAGraphNode_t = c_uint64  # cudaGraphNode_t opaque pointer (CUDA 10.0+)
 # cudaGraphExecEventWaitNodeSetEvent are all CUDA 11.4+ (version integer 11040).
 CUDART_GRAPHS_MIN_VERSION = 11040
 
+# Minimum cudart version that defines cudaDevAttrIpcEventSupport (125).
+# CUDA 11.x tops out at 121 (cudaDevAttrDeferredMappingCudaArraySupported); querying 125
+# against an 11.x runtime returns cudaErrorInvalidValue.
+CUDART_IPC_EVENT_SUPPORT_MIN_VERSION = 12000
+
 # --- CUDA Graph parameter structs ---
 
 

--- a/td_exporter/CUDARuntimeTypes.py
+++ b/td_exporter/CUDARuntimeTypes.py
@@ -95,6 +95,16 @@ class cudaPointerAttributes(ctypes.Structure):
 
     .type values: 0=unregistered, 1=host, 2=device, 3=managed
     .device: GPU index that owns the allocation
+
+    ABI note: CUDA 13.x's driver_types.h added a fifth field, `long reserved[8]`
+    ("Must be zero"), that CUDA 12.x and earlier do not have. Under MSVC x64
+    (`long` = 4 bytes) that grows the struct from 24 to 56 bytes. Since this
+    binding's loader (_load_cuda_runtime() in cuda_ipc_wrapper.py) may attach to
+    either a 12.x or 13.x cudart at runtime, the buffer is always sized to the
+    larger (13.x) layout: an older cudart simply writes fewer bytes into it,
+    which is safe, whereas a 24-byte buffer handed to a 13.x cudart is an
+    undersized out-parameter (out-of-bounds write risk). The four original
+    fields keep their offsets, so .type/.device access is unaffected either way.
     """
 
     _fields_ = [
@@ -102,6 +112,7 @@ class cudaPointerAttributes(ctypes.Structure):
         ("device", c_int),  # GPU device index owning this allocation
         ("devicePointer", c_void_p),
         ("hostPointer", c_void_p),
+        ("reserved", ctypes.c_long * 8),  # CUDA 13.x+ only; unused, must be zero
     ]
 
 
@@ -117,9 +128,17 @@ def _abi_guard(actual: int, expected: int, name: str) -> None:
 
 _abi_guard(ctypes.sizeof(cudaIpcMemHandle_t), 64, "cudaIpcMemHandle_t")
 _abi_guard(ctypes.sizeof(cudaIpcEventHandle_t), 64, "cudaIpcEventHandle_t")
-_abi_guard(ctypes.sizeof(cudaPointerAttributes), 24, "cudaPointerAttributes")
+_abi_guard(ctypes.sizeof(cudaPointerAttributes), 56, "cudaPointerAttributes")
+# Note on what these guards do and don't prove: they only check that THIS module's
+# ctypes _fields_ produce the byte size we intend (a self-consistency check against
+# drift in this file). They cannot detect a struct layout mismatch against whichever
+# cudart DLL is actually loaded at runtime — see the runtime-version check in
+# CUDARuntimeAPI._load_cuda_runtime() / check_ipc_capability() in cuda_ipc_wrapper.py
+# for the runtime-vs-binding side of that problem.
 # Graph param struct ABI guards — cudaMemcpy3DParms is the largest and most alignment-sensitive.
-# All four values were verified against Python ctypes on a 64-bit Windows host (sizeof c_size_t=8).
+# All values were verified against the CUDA 12.8 and 13.3 headers on a 64-bit Windows host
+# (sizeof c_size_t=8); cudaPos/cudaPitchedPtr/cudaExtent/cudaMemcpy3DParms are unchanged
+# between those two toolkit versions.
 _abi_guard(ctypes.sizeof(cudaPos), 24, "cudaPos")
 _abi_guard(ctypes.sizeof(cudaPitchedPtr), 32, "cudaPitchedPtr")
 _abi_guard(ctypes.sizeof(cudaExtent), 24, "cudaExtent")
@@ -229,3 +248,11 @@ IPC_MEM_LAZY_ENABLE_PEER_ACCESS: int = 1
 
 # cudaHostAllocPortable — pinned allocation visible from any CUDA context in the process.
 HOST_ALLOC_PORTABLE: int = 0x01
+
+# --- cudaDeviceAttr values used with get_device_attribute() ---
+# NOTE: cudaDevAttrAsyncEngineCount was previously documented (and used in tests) as 4.
+# Per CUDA 12.8/13.3 driver_types.h it is 40; attribute 4 is cudaDevAttrMaxBlockDimZ, an
+# unrelated value that a caller using the old constant would silently receive instead.
+CUDA_DEV_ATTR_ASYNC_ENGINE_COUNT: int = 40  # cudaDevAttrAsyncEngineCount — DMA copy engine count
+CUDA_DEV_ATTR_IPC_EVENT_SUPPORT: int = 125  # cudaDevAttrIpcEventSupport — 0 if this device/driver
+# cannot support CUDA IPC events (used by check_ipc_capability() in cuda_ipc_wrapper.py)

--- a/td_exporter/Exporter.py
+++ b/td_exporter/Exporter.py
@@ -252,6 +252,15 @@ class Exporter:
             )
         logger.info("Loaded CUDA runtime on device %d", actual_device)
 
+        # Raises only when the driver reports CUDA IPC as flatly unsupported on this
+        # device; Windows WDDM (this project's normal, undocumented-but-validated
+        # configuration — see docs/adr/0004-legacy-cuda-ipc-over-vmm.md) returns a
+        # message here rather than raising. Logged before any IPC handle is minted so
+        # a later error 400/801 has this context available.
+        ipc_capability_note = self._cuda.check_ipc_capability()
+        if ipc_capability_note:
+            logger.info(ipc_capability_note)
+
         hws_mode = _read_hws_mode()
         logger.info("WDDM HwSchMode: %s (0=software, 2=hardware/GPU-P, unknown=non-Windows)", hws_mode)
         if hws_mode == "0":

--- a/td_exporter/ExporterPort.py
+++ b/td_exporter/ExporterPort.py
@@ -297,6 +297,15 @@ class CudaPort(Protocol):
         """Warn and raise if a sticky CUDA error is latched. No-op when all is well."""
         ...
 
+    def check_ipc_capability(self, device: int | None = None) -> str | None:
+        """Probe CUDA IPC support for this device; return a diagnostic string to log.
+
+        Raises only when the driver reports IPC as flatly unsupported (not merely
+        undocumented, e.g. Windows WDDM — which is this project's normal config).
+        See CUDARuntimeAPI.check_ipc_capability() in cuda_ipc_wrapper.py.
+        """
+        ...
+
     # --- CUDA Graphs (optional path; gated by ExportPolicy.use_graphs) ----
 
     def get_runtime_version(self) -> int:

--- a/td_exporter/HELP_DOC.md
+++ b/td_exporter/HELP_DOC.md
@@ -320,7 +320,7 @@ total (D2H streaming, activation barriers, CUDA Graphs, NVTX profiling, etc.). S
 | Cross-process IPC notify latency | ~136–286 µs | Poll-sleep baseline; `CUDALINK_WAIT_BACKEND=native` targets p50 < 10 µs |
 | First-frame initialization | 50–100 µs | One-time GPU buffer allocation + IPC handle creation |
 | `export_frame()` (1080p RGBA float32) | ~106 µs | Standalone Python `Exporter`, EXPORT_SYNC=1, RTX 4090 — full D2D copy + IPC record, runs on GPU |
-| Receiver `copyCUDAMemory` into TD (1080p) | ~130 µs | Typical measured value (see the Receiver Debug example above); includes CUDA→OpenGL interop inside TD |
+| Receiver `copyCUDAMemory` into TD (1080p) | ~130 µs | Typical measured value (see the Receiver Debug example above); includes CUDA→Vulkan interop inside TD |
 | D2H numpy copy (1080p RGBA float32) | ~1.3 ms | Only when using `get_frame_numpy()`; avoided entirely by `get_frame()` (zero-copy GPU tensor) |
 
 **Baseline comparison:** CPU SharedMemory at 1080p RGBA float32 costs **~5.4 ms** end-to-end
@@ -357,7 +357,7 @@ producer-side write alone 4–19× faster. Numbers from `docs/BENCHMARKS.md`
 
 **Sender `export=` windowed average is higher than expected**
 
-- The `top_op.cudaMemory()` OpenGL→CUDA interop call happens *before* the timed `export_frame()` region and is not broken out as a separate Debug metric — it is not controllable by this component and is normal for large textures or when the GPU is under heavy load. If `export=` itself (or the `[PROFILE]` `memcpy=`/`sync=` fields) is high, that points to the D2D copy or blocking sync instead.
+- The `top_op.cudaMemory()` Vulkan→CUDA interop call happens *before* the timed `export_frame()` region and is not broken out as a separate Debug metric — it is not controllable by this component and is normal for large textures or when the GPU is under heavy load. If `export=` itself (or the `[PROFILE]` `memcpy=`/`sync=` fields) is high, that points to the D2D copy or blocking sync instead.
 
 **Consumer crashes with CUDA 719 / `cudaErrorLaunchFailure` after receiving IPC frames**
 
@@ -373,8 +373,12 @@ producer-side write alone 4–19× faster. Numbers from `docs/BENCHMARKS.md`
 
 ## Requirements
 
-- **OS:** Windows 10 / 11 (CUDA IPC handle sharing is Windows-only)
+- **OS:** Windows 10 / 11. NVIDIA documents the legacy `cudaIpc*` API as Linux-only, and on
+  Windows as supported only under the TCC driver model — this project runs it on the default
+  WDDM driver model instead, which works in practice (see
+  `docs/adr/0004-legacy-cuda-ipc-over-vmm.md`) but is outside NVIDIA's documented support
+  envelope.
 - **CUDA:** 11.x, 12.x, or 13.x runtime (the loader prefers 13.x/12.x, tested with 12.4 and 12.8; 11.x accepted as a fallback for systems that haven't migrated)
-- **GPU:** NVIDIA, CUDA compute capability 3.5 or higher
+- **GPU:** Any NVIDIA GPU supporting the CUDA runtime IPC and Graphs APIs used above
 - **TouchDesigner:** 2022.x or later
 - **Python (consumer side):** 3.11+ recommended (matches TouchDesigner's bundled interpreter). The prebuilt native wheel targets **cp311 (Python 3.11)**; a `py3-none-any` pure-Python fallback wheel also installs on 3.9+ interpreters if needed. Not published on PyPI — see [Quick Start](#quick-start) for install instructions.

--- a/tests/core/test_exporter_cov_init.py
+++ b/tests/core/test_exporter_cov_init.py
@@ -113,6 +113,40 @@ def test_open_device_mismatch_raises_cuda_ipc_error_and_cleans_up() -> None:
 
 
 # ---------------------------------------------------------------------------
+# _initialize() — check_ipc_capability() wiring
+# ---------------------------------------------------------------------------
+
+
+def test_initialize_logs_ipc_capability_note_when_present() -> None:
+    """A non-None check_ipc_capability() return is logged via logger.info before
+    any IPC handle is minted (see the ipc_capability_note comment in _initialize())."""
+    fake = FakeCUDAAdapter(device=0)
+    fake.check_ipc_capability = lambda device=None: "WDDM driver model; legacy CUDA IPC is undocumented here."
+    with patch("cuda_link.exporter.logger") as mock_logger:
+        exp = Exporter.open(_spec(), policy=ExportPolicy.for_testing(), cuda=fake)
+    try:
+        messages = [str(c.args[0]) for c in mock_logger.info.call_args_list if c.args]
+        assert any("WDDM driver model" in m for m in messages)
+    finally:
+        exp.close()
+
+
+def test_initialize_propagates_ipc_capability_failure_and_cleans_up() -> None:
+    """cudaDevAttrIpcEventSupport == 0 -> check_ipc_capability() raises -> open()
+    propagates it and still runs cleanup (mirrors the device-mismatch test above)."""
+    fake = FakeCUDAAdapter(device=0)
+    fake.fail_ipc_capability = True
+    original_do_cleanup = Exporter._do_cleanup
+    with (
+        patch.object(Exporter, "_do_cleanup", autospec=True, side_effect=original_do_cleanup) as mock_cleanup,
+        pytest.raises(RuntimeError, match="simulated cudaDevAttrIpcEventSupport=0"),
+    ):
+        Exporter.open(_spec(), policy=ExportPolicy.for_testing(), cuda=fake)
+    mock_cleanup.assert_called_once()
+    assert mock_cleanup.call_args.kwargs["cuda_valid"] is False
+
+
+# ---------------------------------------------------------------------------
 # _initialize() — HWS=0 performance warning (257)
 # ---------------------------------------------------------------------------
 

--- a/tests/core/test_importer_cov_buffers.py
+++ b/tests/core/test_importer_cov_buffers.py
@@ -8,6 +8,7 @@ matching the established pattern in tests/core/test_importer.py.
 
 from __future__ import annotations
 
+import sys
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -149,8 +150,17 @@ def _fmt(shape=(2, 2, 4), dtype="uint8") -> Format:
     return Format.from_overrides(shape, dtype)
 
 
-def test_numpy_buffers_build_raises_for_dtype_with_no_numpy_representation() -> None:
-    """bfloat16 without ml_dtypes -> numpy_dtype is None -> explicit ValueError."""
+def test_numpy_buffers_build_raises_for_dtype_with_no_numpy_representation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """bfloat16 without ml_dtypes -> numpy_dtype is None -> explicit ValueError.
+
+    ml_dtypes may or may not be installed in the ambient environment (it's an
+    optional dependency), so force the "absent" branch of _numpy_dtype_for()'s
+    inline `import ml_dtypes` by making that import raise ImportError -- this
+    is the documented sys.modules[name] = None technique, not a real removal.
+    """
+    monkeypatch.setitem(sys.modules, "ml_dtypes", None)
     conn, _, _ = make_fake_ipc_connection(num_slots=1)
     fmt = _fmt(dtype="bfloat16")
     assert fmt.numpy_dtype is None

--- a/tests/cuda/test_wrapper_cov_methods.py
+++ b/tests/cuda/test_wrapper_cov_methods.py
@@ -724,6 +724,52 @@ def test_get_device_attribute_uses_explicit_device() -> None:
 
 
 # ---------------------------------------------------------------------------
+# _check_pointer_attributes_abi
+# ---------------------------------------------------------------------------
+
+
+def test_check_pointer_attributes_abi_warns_on_unrecognized_future_runtime(caplog) -> None:
+    """A CUDA 14.x runtime post-dates every cudaPointerAttributes layout this binding
+
+    has verified, so the method must warn — that warning is its entire purpose.
+    """
+    import logging
+
+    api = make_bare_runtime_api()
+    _mock_runtime_version(api, 14000)
+
+    with caplog.at_level(logging.WARNING, logger="cuda_link.cuda_ipc_wrapper"):
+        api._check_pointer_attributes_abi()
+
+    assert any("newer than any" in rec.message for rec in caplog.records)
+
+
+def test_check_pointer_attributes_abi_debug_logs_13x_layout(caplog) -> None:
+    import logging
+
+    api = make_bare_runtime_api()
+    _mock_runtime_version(api, 13000)
+
+    with caplog.at_level(logging.DEBUG, logger="cuda_link.cuda_ipc_wrapper"):
+        api._check_pointer_attributes_abi()
+
+    assert any("56 bytes" in rec.message for rec in caplog.records)
+    assert not any(rec.levelno >= logging.WARNING for rec in caplog.records)
+
+
+def test_check_pointer_attributes_abi_debug_logs_legacy_layout(caplog) -> None:
+    import logging
+
+    api = make_bare_runtime_api()
+    _mock_runtime_version(api, 12080)
+
+    with caplog.at_level(logging.DEBUG, logger="cuda_link.cuda_ipc_wrapper"):
+        api._check_pointer_attributes_abi()
+
+    assert any("24 bytes" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
 # check_ipc_capability
 # ---------------------------------------------------------------------------
 
@@ -819,3 +865,42 @@ def test_check_ipc_capability_degrades_on_query_failure() -> None:
 
     assert msg is not None
     assert "could not query" in msg.lower()
+
+
+def test_check_ipc_capability_survives_runtime_version_failure() -> None:
+    """get_runtime_version() failing must not abort the probe — it degrades to
+
+    version 0, which then takes the pre-12.0 skip path. This probe is diagnostic
+    and must never be able to abort Exporter.open().
+    """
+    api = make_bare_runtime_api()
+    api.device = 0
+    api.cudart.cudaRuntimeGetVersion.side_effect = RuntimeError("cudart not loaded")
+
+    msg = api.check_ipc_capability()
+
+    assert msg is not None
+    assert "runtime version 0" in msg
+    api.cudart.cudaDeviceGetAttribute.assert_not_called()
+
+
+def test_check_ipc_capability_uses_explicit_device(monkeypatch: pytest.MonkeyPatch) -> None:
+    import cuda_link.cuda_ipc_wrapper as _w
+
+    monkeypatch.setattr(_w, "os", SimpleNamespace(name="nt"))
+    api = make_bare_runtime_api()
+    api.device = 0
+    _mock_runtime_version(api, 12080)
+    seen: dict[str, int] = {}
+
+    def _attr(value_ptr, attr, device):
+        seen["device"] = device.value
+        _fill_scalar_byref(value_ptr, c_int, 1)
+        return 0
+
+    api.cudart.cudaDeviceGetAttribute.side_effect = _attr
+
+    msg = api.check_ipc_capability(device=3)
+
+    assert seen["device"] == 3
+    assert msg is not None and "device 3" in msg

--- a/tests/cuda/test_wrapper_cov_methods.py
+++ b/tests/cuda/test_wrapper_cov_methods.py
@@ -24,6 +24,7 @@ No @pytest.mark.requires_cuda / requires_native marker needed.
 from __future__ import annotations
 
 from ctypes import POINTER, c_float, c_int, c_void_p, cast
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -699,20 +700,70 @@ def test_malloc_host_alloc_uses_portable_flag_by_default() -> None:
 
 
 def test_get_device_attribute_defaults_to_self_device() -> None:
+    from cuda_link.cuda_runtime_types import CUDA_DEV_ATTR_ASYNC_ENGINE_COUNT
+
     api = make_bare_runtime_api()
     api.device = 5
 
-    api.get_device_attribute(4)
+    api.get_device_attribute(CUDA_DEV_ATTR_ASYNC_ENGINE_COUNT)
 
     args = api.cudart.cudaDeviceGetAttribute.call_args[0]
     assert args[2].value == 5
 
 
 def test_get_device_attribute_uses_explicit_device() -> None:
+    from cuda_link.cuda_runtime_types import CUDA_DEV_ATTR_ASYNC_ENGINE_COUNT
+
     api = make_bare_runtime_api()
     api.device = 5
 
-    api.get_device_attribute(4, device=2)
+    api.get_device_attribute(CUDA_DEV_ATTR_ASYNC_ENGINE_COUNT, device=2)
 
     args = api.cudart.cudaDeviceGetAttribute.call_args[0]
     assert args[2].value == 2
+
+
+# ---------------------------------------------------------------------------
+# check_ipc_capability
+# ---------------------------------------------------------------------------
+
+
+def test_check_ipc_capability_returns_none_when_not_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    import cuda_link.cuda_ipc_wrapper as _w
+
+    # Rebind the module-local `os` name (not the real os module — mutating the real
+    # os.name process-wide breaks pathlib.Path.__new__, which pytest itself uses).
+    monkeypatch.setattr(_w, "os", SimpleNamespace(name="posix"))
+    api = make_bare_runtime_api()
+    api.device = 0
+    api.cudart.cudaDeviceGetAttribute.side_effect = lambda value_ptr, attr, device: (
+        _fill_scalar_byref(value_ptr, c_int, 1) or 0
+    )
+
+    assert api.check_ipc_capability() is None
+
+
+def test_check_ipc_capability_returns_diagnostic_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    import cuda_link.cuda_ipc_wrapper as _w
+
+    monkeypatch.setattr(_w, "os", SimpleNamespace(name="nt"))
+    api = make_bare_runtime_api()
+    api.device = 0
+    api.cudart.cudaDeviceGetAttribute.side_effect = lambda value_ptr, attr, device: (
+        _fill_scalar_byref(value_ptr, c_int, 1) or 0
+    )
+
+    msg = api.check_ipc_capability()
+    assert msg is not None
+    assert "IPC" in msg
+
+
+def test_check_ipc_capability_raises_when_support_is_zero() -> None:
+    api = make_bare_runtime_api()
+    api.device = 0
+    api.cudart.cudaDeviceGetAttribute.side_effect = lambda value_ptr, attr, device: (
+        _fill_scalar_byref(value_ptr, c_int, 0) or 0
+    )
+
+    with pytest.raises(CudaIpcError, match="cudaDevAttrIpcEventSupport=0"):
+        api.check_ipc_capability()

--- a/tests/cuda/test_wrapper_cov_methods.py
+++ b/tests/cuda/test_wrapper_cov_methods.py
@@ -728,6 +728,18 @@ def test_get_device_attribute_uses_explicit_device() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _mock_runtime_version(api: object, version: int) -> None:
+    """Make api.get_runtime_version() (cudaRuntimeGetVersion) report `version`.
+
+    Mirrors _fill_scalar_byref's byref-writeback trick, but cudaRuntimeGetVersion
+    takes a single out-param (no attr/device args), so the side_effect signature
+    differs from cudaDeviceGetAttribute's.
+    """
+    api.cudart.cudaRuntimeGetVersion.side_effect = lambda version_ptr: (
+        _fill_scalar_byref(version_ptr, c_int, version) or 0
+    )
+
+
 def test_check_ipc_capability_returns_none_when_not_windows(monkeypatch: pytest.MonkeyPatch) -> None:
     import cuda_link.cuda_ipc_wrapper as _w
 
@@ -736,6 +748,7 @@ def test_check_ipc_capability_returns_none_when_not_windows(monkeypatch: pytest.
     monkeypatch.setattr(_w, "os", SimpleNamespace(name="posix"))
     api = make_bare_runtime_api()
     api.device = 0
+    _mock_runtime_version(api, 12080)
     api.cudart.cudaDeviceGetAttribute.side_effect = lambda value_ptr, attr, device: (
         _fill_scalar_byref(value_ptr, c_int, 1) or 0
     )
@@ -749,6 +762,7 @@ def test_check_ipc_capability_returns_diagnostic_on_windows(monkeypatch: pytest.
     monkeypatch.setattr(_w, "os", SimpleNamespace(name="nt"))
     api = make_bare_runtime_api()
     api.device = 0
+    _mock_runtime_version(api, 12080)
     api.cudart.cudaDeviceGetAttribute.side_effect = lambda value_ptr, attr, device: (
         _fill_scalar_byref(value_ptr, c_int, 1) or 0
     )
@@ -761,9 +775,47 @@ def test_check_ipc_capability_returns_diagnostic_on_windows(monkeypatch: pytest.
 def test_check_ipc_capability_raises_when_support_is_zero() -> None:
     api = make_bare_runtime_api()
     api.device = 0
+    _mock_runtime_version(api, 12080)
     api.cudart.cudaDeviceGetAttribute.side_effect = lambda value_ptr, attr, device: (
         _fill_scalar_byref(value_ptr, c_int, 0) or 0
     )
 
     with pytest.raises(CudaIpcError, match="cudaDevAttrIpcEventSupport=0"):
         api.check_ipc_capability()
+
+
+def test_check_ipc_capability_skips_query_on_pre_12_runtime() -> None:
+    """CUDA 11.x (e.g. TouchDesigner's cudart64_110.dll) predates attribute 125
+
+    (cudaDevAttrIpcEventSupport, added in CUDA 12.0). Querying it on an 11.x
+    runtime returns an invalid-attribute error; the probe must skip the query
+    entirely rather than let that error abort Exporter.open() (PR #30 review
+    finding: this previously aborted init on 11.x).
+    """
+    api = make_bare_runtime_api()
+    api.device = 0
+    _mock_runtime_version(api, 11080)  # CUDA 11.8 — last 11.x release
+
+    msg = api.check_ipc_capability()
+
+    assert msg is not None
+    assert "11080" in msg
+    api.cudart.cudaDeviceGetAttribute.assert_not_called()
+
+
+def test_check_ipc_capability_degrades_on_query_failure() -> None:
+    """An unexpected query failure (e.g. attribute unsupported on this driver)
+
+    must degrade to a diagnostic string rather than propagate — the probe's
+    sole job is diagnostics, and only an explicit support==0 result should be
+    able to raise.
+    """
+    api = make_bare_runtime_api()
+    api.device = 0
+    _mock_runtime_version(api, 12080)
+    api.cudart.cudaDeviceGetAttribute.side_effect = CudaIpcError("cudaDeviceGetAttribute failed: boom")
+
+    msg = api.check_ipc_capability()
+
+    assert msg is not None
+    assert "could not query" in msg.lower()

--- a/tests/support/test_cuda_adapters_cov.py
+++ b/tests/support/test_cuda_adapters_cov.py
@@ -125,3 +125,20 @@ def test_record_event_external_uses_str_fallback_for_untagged_objects():
     # Exact fallback content, not just "something got recorded" — catches a swapped
     # event/stream order or a wrong/constant fallback value.
     assert adapter.recorded_events == [(str(event), str(stream))]
+
+
+# ---------------------------------------------------------------------------
+# FakeCUDAAdapter.check_ipc_capability — failure injection branch
+# ---------------------------------------------------------------------------
+
+
+def test_check_ipc_capability_returns_none_by_default():
+    adapter = FakeCUDAAdapter()
+    assert adapter.check_ipc_capability() is None
+
+
+def test_check_ipc_capability_raises_when_injected():
+    adapter = FakeCUDAAdapter()
+    adapter.fail_ipc_capability = True
+    with pytest.raises(RuntimeError, match="simulated cudaDevAttrIpcEventSupport=0"):
+        adapter.check_ipc_capability()

--- a/tests/support/test_cuda_adapters_cov.py
+++ b/tests/support/test_cuda_adapters_cov.py
@@ -142,3 +142,12 @@ def test_check_ipc_capability_raises_when_injected():
     adapter.fail_ipc_capability = True
     with pytest.raises(RuntimeError, match="simulated cudaDevAttrIpcEventSupport=0"):
         adapter.check_ipc_capability()
+
+
+def test_check_ipc_capability_message_preserves_explicit_device_zero():
+    # device=0 is falsy in Python — `device or self.device` would silently substitute
+    # self.device (1) here instead. Regression guard for that truthiness bug.
+    adapter = FakeCUDAAdapter(device=1)
+    adapter.fail_ipc_capability = True
+    with pytest.raises(RuntimeError, match="for device 0"):
+        adapter.check_ipc_capability(device=0)


### PR DESCRIPTION
## Changes

- 4fbe865 chore: bump version to 1.12.2 + update CHANGELOG
- baca8b5 fix: cudaPointerAttributes ABI drift on CUDA 13.x

## Branch

`fix/cuda-ipc-verification-findings` -> `development`