### PR TITLE
chore: promote harden-test-suite campaign, docs fix, and hook guard to master

### DIFF
--- a/.claude/hooks/cc-block-dangerous-git.sh
+++ b/.claude/hooks/cc-block-dangerous-git.sh
@@ -13,6 +13,11 @@
 # degrades gracefully (logs a warning, allows the command through) rather than
 # breaking the user's shell.
 #
+# Heuristic limits (defense-in-depth, not a sandbox): this hook does not evaluate
+# `eval`, shell aliases/functions, `git -C <path> <subcmd>` (the subcommand isn't
+# adjacent to `git`), or paths hidden inside quotes — e.g. `rm -rf "$HOME/.git"`
+# is stripped by the quote-stripping heuristic below before pattern matching runs.
+#
 # To uninstall: remove the PreToolUse entry from .claude/settings.json and
 #   delete this file.
 # To temporarily disable: set SKIP_CGW_GUARDRAIL=1 in your environment.
@@ -41,6 +46,15 @@ COMMAND=$(jq -r '.tool_input.command // empty' <<< "${INPUT}" 2>/dev/null)
 # (does not handle nested/escaped quotes, but covers all practical CGW cases).
 COMMAND_UNQUOTED=$(sed 's/"[^"]*"//g; s/'"'"'[^'"'"']*'"'"'//g' <<< "${COMMAND}")
 
+# Split into individual shell invocations before pattern matching, so a flag or
+# exemption belonging to one command (e.g. `--cached` after a `;`) cannot satisfy
+# a check for a different, earlier command on the same line. Join backslash-
+# newline continuations first so a wrapped command stays one invocation, then
+# split on shell separators (; | & newline). `&&` / `||` produce an empty
+# segment, which matches no pattern and is harmlessly skipped.
+COMMAND_JOINED="${COMMAND_UNQUOTED//\\$'\n'/ }"
+COMMAND_SEGMENTED="${COMMAND_JOINED//[;|&$'\n']/$'\n'}"
+
 # ── Block helper ──────────────────────────────────────────────────────────────
 
 _block() {
@@ -52,91 +66,139 @@ _block() {
 }
 
 # ── Pattern checks ────────────────────────────────────────────────────────────
-# Each check: if the command matches the pattern, block with a redirect message.
+# Each invocation (one shell command — see segmentation above) is checked in
+# isolation with bash's built-in [[ =~ ]] regex operator against a padded copy
+# (" ${cmd} "), so every token is whitespace-delimited on both sides. That
+# absorbs tabs/repeated spaces without spawning a subprocess per check — with
+# segmentation multiplying the check count by segment count, per-check grep
+# subprocesses would be visibly slow under Git Bash on Windows.
 # CGW wrapper scripts in scripts/git/ are trusted; their subprocesses
 # are not intercepted by this hook (PreToolUse only fires for direct Bash calls).
 
-# Raw git commit — bypasses lint, local-file protection, conventional commit enforcement
-grep -qE 'git commit( |$)' <<< "${COMMAND_UNQUOTED}" \
-  && _block 'git commit' \
-     'Use ./scripts/git/commit_enhanced.sh "<type>: <msg>" instead — it runs lint, protects local-only files, and enforces conventional commit format.'
+_check_invocation() {
+  local padded=" $1 "
 
-# --no-verify — bypasses pre-commit and pre-push hooks entirely
-grep -qE -- '--no-verify' <<< "${COMMAND_UNQUOTED}" \
-  && _block '--no-verify' \
-     'CGW pre-commit/pre-push hooks cannot be bypassed with --no-verify. Fix the underlying issue (run ./scripts/git/fix_lint.sh for lint errors, or inspect the hook output).'
+  # Reusable flag fragments (unquoted so [[ =~ ]] treats them as regex, not literals)
+  local _force='[[:space:]](-[A-Za-z]*f[A-Za-z]*|--force)[[:space:]]'
+  local _cached='[[:space:]]--cached([[:space:]]|=)'
+  local _dryrun='[[:space:]](-[A-Za-z]*n[A-Za-z]*|--dry-run)[[:space:]]'
+  local _dot='[[:space:]][.][[:space:]]'
+  local _staged='[[:space:]]--staged([[:space:]]|=)'
+  local _worktree='[[:space:]]--worktree([[:space:]]|=)'
 
-# Force-push without lease — overwrites others work and bypasses protection
-# Note: --force-with-lease is explicitly allowed (it is what push_validated.sh uses)
-grep -qE 'git push --force( |$)' <<< "${COMMAND_UNQUOTED}" \
-  && _block 'git push --force' \
-     'Use ./scripts/git/push_validated.sh instead — it uses --force-with-lease and requires confirmation on protected branches. Note: --force-with-lease is allowed.'
+  # Raw git commit — bypasses lint, local-file protection, conventional commit enforcement
+  if [[ ${padded} =~ git[[:space:]]+commit[[:space:]] ]]; then
+    _block 'git commit' \
+      'Use ./scripts/git/commit_enhanced.sh "<type>: <msg>" instead — it runs lint, protects local-only files, and enforces conventional commit format.'
+  fi
 
-# Hard reset — irreversibly discards uncommitted work and index changes
-grep -qE 'git reset --hard' <<< "${COMMAND_UNQUOTED}" \
-  && _block 'git reset --hard' \
-     'Confirm with the user before running git reset --hard. This irreversibly discards uncommitted work and index changes.'
+  # --no-verify — bypasses pre-commit and pre-push hooks entirely
+  if [[ ${padded} =~ [[:space:]]--no-verify([[:space:]]|=) ]]; then
+    _block '--no-verify' \
+      'CGW pre-commit/pre-push hooks cannot be bypassed with --no-verify. Fix the underlying issue (run ./scripts/git/fix_lint.sh for lint errors, or inspect the hook output).'
+  fi
 
-# git clean -f — permanently deletes untracked files (covers -f, -fd, -fdx)
-grep -qE 'git clean -f' <<< "${COMMAND_UNQUOTED}" \
-  && _block 'git clean -f' \
-     'Confirm with the user before running git clean. This permanently deletes untracked files from the working tree.'
+  # Force-push without lease — overwrites others' work and bypasses protection.
+  # --force-with-lease is explicitly allowed (it is what push_validated.sh uses):
+  # a '-' follows "--force" in that flag, so the trailing [[:space:]] never matches.
+  if [[ ${padded} =~ git[[:space:]]+push[[:space:]] ]] && [[ ${padded} =~ ${_force} ]]; then
+    _block 'git push --force' \
+      'Use ./scripts/git/push_validated.sh instead — it uses --force-with-lease and requires confirmation on protected branches. Note: --force-with-lease is allowed.'
+  fi
 
-# git rm with a force flag deletes files from the WORKING TREE. git itself refuses
-# `git rm` on modified/added files ("use -f to force"); -f overrides that and can
-# UNRECOVERABLY delete git-ignored / untracked-turned-added files (e.g. local-only
-# artifacts staged by `git cherry-pick -n`). --cached is index-only (keeps the file
-# on disk — the documented untrack workflow), so a --cached command is always allowed.
-if grep -qE 'git rm( |$)' <<< "${COMMAND_UNQUOTED}" \
-   && ! grep -qE -- '--cached' <<< "${COMMAND_UNQUOTED}" \
-   && grep -qE -- '(^|[[:space:]])(-[A-Za-z]*f[A-Za-z]*|--force)([[:space:]]|$)' <<< "${COMMAND_UNQUOTED}"; then
-  _block 'git rm -f' \
-    'git rm -f deletes files from the working tree — for git-ignored or untracked files this is UNRECOVERABLE. To untrack a file while keeping it on disk, use git rm --cached <path>. To force-delete a tracked file, confirm with the user first.'
-fi
+  # Hard reset — irreversibly discards uncommitted work and index changes
+  if [[ ${padded} =~ git[[:space:]]+reset[[:space:]] ]] && [[ ${padded} =~ [[:space:]]--hard([[:space:]]|=) ]]; then
+    _block 'git reset --hard' \
+      'Confirm with the user before running git reset --hard. This irreversibly discards uncommitted work and index changes.'
+  fi
 
-# Force-delete branch — may lose commits on an unmerged branch
-grep -qE 'git branch -D( |$)' <<< "${COMMAND_UNQUOTED}" \
-  && _block 'git branch -D' \
-     'Use ./scripts/git/branch_cleanup.sh --execute to prune merged branches, or confirm with the user before force-deleting an unmerged branch.'
+  # git clean -f — permanently deletes untracked files (covers -f, -fd, -df, -fdx, ...).
+  # A dry-run flag (-n / --dry-run) only previews the deletion, so it is exempt.
+  if [[ ${padded} =~ git[[:space:]]+clean[[:space:]] ]] \
+     && [[ ${padded} =~ ${_force} ]] \
+     && ! [[ ${padded} =~ ${_dryrun} ]]; then
+    _block 'git clean -f' \
+      'Confirm with the user before running git clean. This permanently deletes untracked files from the working tree.'
+  fi
 
-# Discard all working-tree changes (. = current directory = everything)
-grep -qE 'git checkout \.( |$)' <<< "${COMMAND_UNQUOTED}" \
-  && _block 'git checkout .' \
-     'Confirm with the user — git checkout . irreversibly discards all working-tree changes.'
+  # git rm with a force flag deletes files from the WORKING TREE. git itself refuses
+  # `git rm` on modified/added files ("use -f to force"); -f overrides that and can
+  # UNRECOVERABLY delete git-ignored / untracked-turned-added files (e.g. local-only
+  # artifacts staged by `git cherry-pick -n`). --cached is index-only (keeps the file
+  # on disk — the documented untrack workflow), so a --cached in the SAME invocation
+  # is always allowed.
+  if [[ ${padded} =~ git[[:space:]]+rm[[:space:]] ]] \
+     && ! [[ ${padded} =~ ${_cached} ]] \
+     && [[ ${padded} =~ ${_force} ]]; then
+    _block 'git rm -f' \
+      'git rm -f deletes files from the working tree — for git-ignored or untracked files this is UNRECOVERABLE. To untrack a file while keeping it on disk, use git rm --cached <path>. To force-delete a tracked file, confirm with the user first.'
+  fi
 
-grep -qE 'git restore \.( |$)' <<< "${COMMAND_UNQUOTED}" \
-  && _block 'git restore .' \
-     'Confirm with the user — git restore . irreversibly discards all working-tree changes.'
+  # Force-delete branch — may lose commits on an unmerged branch (-D, not -d)
+  if [[ ${padded} =~ git[[:space:]]+branch[[:space:]] ]] \
+     && [[ ${padded} =~ [[:space:]]-[A-Za-z]*D[A-Za-z]*[[:space:]] ]]; then
+    _block 'git branch -D' \
+      'Use ./scripts/git/branch_cleanup.sh --execute to prune merged branches, or confirm with the user before force-deleting an unmerged branch.'
+  fi
 
-# History rewrites — permanently alter commit history; extremely destructive
-grep -qE 'git filter-branch' <<< "${COMMAND_UNQUOTED}" \
-  && _block 'git filter-branch' \
-     'Destructive history rewrite — confirm with the user before proceeding.'
+  # Discard all working-tree changes (. = current directory = everything)
+  if [[ ${padded} =~ git[[:space:]]+checkout[[:space:]] ]] && [[ ${padded} =~ ${_dot} ]]; then
+    _block 'git checkout .' \
+      'Confirm with the user — git checkout . irreversibly discards all working-tree changes.'
+  fi
 
-grep -qE 'git filter-repo' <<< "${COMMAND_UNQUOTED}" \
-  && _block 'git filter-repo' \
-     'Destructive history rewrite — confirm with the user before proceeding.'
+  if [[ ${padded} =~ git[[:space:]]+restore[[:space:]] ]] && [[ ${padded} =~ ${_dot} ]]; then
+    # --staged alone only touches the index (reversible with `git reset`) — exempt.
+    # --staged combined with --worktree (or --worktree/default alone) discards
+    # working-tree changes and stays blocked.
+    if ! { [[ ${padded} =~ ${_staged} ]] && ! [[ ${padded} =~ ${_worktree} ]]; }; then
+      _block 'git restore .' \
+        'Confirm with the user — git restore . irreversibly discards all working-tree changes.'
+    fi
+  fi
 
-# Recovery ref destruction — eliminates the ability to recover lost commits
-grep -qE 'git reflog expire' <<< "${COMMAND_UNQUOTED}" \
-  && _block 'git reflog expire' \
-     'This destroys reflog recovery references — confirm with the user.'
+  # History rewrites — permanently alter commit history; extremely destructive
+  if [[ ${padded} =~ git[[:space:]]+filter-branch[[:space:]] ]]; then
+    _block 'git filter-branch' \
+      'Destructive history rewrite — confirm with the user before proceeding.'
+  fi
 
-grep -qE 'git gc --prune=now' <<< "${COMMAND_UNQUOTED}" \
-  && _block 'git gc --prune=now' \
-     'This destroys unreachable objects needed for recovery — confirm with the user.'
+  if [[ ${padded} =~ git[[:space:]]+filter-repo[[:space:]] ]]; then
+    _block 'git filter-repo' \
+      'Destructive history rewrite — confirm with the user before proceeding.'
+  fi
 
-grep -qE 'git update-ref -d' <<< "${COMMAND_UNQUOTED}" \
-  && _block 'git update-ref -d' \
-     'Destructive ref operation — confirm with the user.'
+  # Recovery ref destruction — eliminates the ability to recover lost commits
+  if [[ ${padded} =~ git[[:space:]]+reflog[[:space:]]+expire[[:space:]] ]]; then
+    _block 'git reflog expire' \
+      'This destroys reflog recovery references — confirm with the user.'
+  fi
 
-# .git directory destruction
-# Catches: rm -rf .git  rm -rf .git/  rm -rf /path/to/.git
-# Allows:  rm -rf .gitignore  rm -rf .github  (character after .git is alphanumeric)
-if grep -qE 'rm -rf' <<< "${COMMAND_UNQUOTED}" \
-   && grep -qE '[.]git(/| |$)' <<< "${COMMAND_UNQUOTED}"; then
-  _block 'rm -rf .git' \
-    'This would destroy the git repository — confirm with the user first.'
-fi
+  if [[ ${padded} =~ git[[:space:]]+gc[[:space:]] ]] && [[ ${padded} =~ [[:space:]]--prune=now[[:space:]] ]]; then
+    _block 'git gc --prune=now' \
+      'This destroys unreachable objects needed for recovery — confirm with the user.'
+  fi
+
+  if [[ ${padded} =~ git[[:space:]]+update-ref[[:space:]] ]] \
+     && [[ ${padded} =~ [[:space:]]-[A-Za-z]*d[A-Za-z]*[[:space:]] ]]; then
+    _block 'git update-ref -d' \
+      'Destructive ref operation — confirm with the user.'
+  fi
+
+  # .git directory destruction
+  # Catches: rm -rf .git  rm -r -f .git  rm -rf .git/  rm -rf /path/to/.git
+  # Allows:  rm -rf .gitignore  rm -rf .github  (character after .git is alphanumeric)
+  if [[ ${padded} =~ [[:space:]]rm[[:space:]] ]] \
+     && [[ ${padded} =~ [[:space:]]-[A-Za-z]*r[A-Za-z]*[[:space:]] ]] \
+     && [[ ${padded} =~ ${_force} ]] \
+     && [[ ${padded} =~ [.]git(/|[[:space:]]) ]]; then
+    _block 'rm -rf .git' \
+      'This would destroy the git repository — confirm with the user first.'
+  fi
+}
+
+while IFS= read -r _invocation; do
+  _check_invocation "${_invocation}"
+done <<< "${COMMAND_SEGMENTED}"
 
 exit 0

--- a/.claude/hooks/cc-block-dangerous-git.sh
+++ b/.claude/hooks/cc-block-dangerous-git.sh
@@ -82,6 +82,18 @@ grep -qE 'git clean -f' <<< "${COMMAND_UNQUOTED}" \
   && _block 'git clean -f' \
      'Confirm with the user before running git clean. This permanently deletes untracked files from the working tree.'
 
+# git rm with a force flag deletes files from the WORKING TREE. git itself refuses
+# `git rm` on modified/added files ("use -f to force"); -f overrides that and can
+# UNRECOVERABLY delete git-ignored / untracked-turned-added files (e.g. local-only
+# artifacts staged by `git cherry-pick -n`). --cached is index-only (keeps the file
+# on disk — the documented untrack workflow), so a --cached command is always allowed.
+if grep -qE 'git rm( |$)' <<< "${COMMAND_UNQUOTED}" \
+   && ! grep -qE -- '--cached' <<< "${COMMAND_UNQUOTED}" \
+   && grep -qE -- '(^|[[:space:]])(-[A-Za-z]*f[A-Za-z]*|--force)([[:space:]]|$)' <<< "${COMMAND_UNQUOTED}"; then
+  _block 'git rm -f' \
+    'git rm -f deletes files from the working tree — for git-ignored or untracked files this is UNRECOVERABLE. To untrack a file while keeping it on disk, use git rm --cached <path>. To force-delete a tracked file, confirm with the user first.'
+fi
+
 # Force-delete branch — may lose commits on an unmerged branch
 grep -qE 'git branch -D( |$)' <<< "${COMMAND_UNQUOTED}" \
   && _block 'git branch -D' \

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         continue-on-error: true  # Don't fail PR status if Claude has issues
-        uses: anthropics/claude-code-action@1623c36729ac1cd5895198cded705a287de7db79  # v1.0.187
+        uses: anthropics/claude-code-action@9d7150bc8a3dae8149739a88019d192b579ad90c  # v1.0.193
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "*"  # Allow all bots (including claude[bot])

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@1623c36729ac1cd5895198cded705a287de7db79  # v1.0.187
+        uses: anthropics/claude-code-action@9d7150bc8a3dae8149739a88019d192b579ad90c  # v1.0.193
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "*"  # Allow all bots (including claude[bot])

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ htmlcov/
 .coverage.*
 .cache
 nosetests.xml
+lcov.info
 coverage.xml
 *.cover
 *.py,cover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   since this project's whole premise is that legacy CUDA IPC works there in practice; raises
   only when the driver reports IPC flatly unsupported (`cudaDevAttrIpcEventSupport == 0`).
 
-### Docs
+### Documentation
 
 - Corrected the inverted CUDA-IPC platform-support claim in `README.md` and
   `td_exporter/HELP_DOC.md` — NVIDIA documents the legacy IPC API as Linux/Windows-TCC only;
@@ -989,7 +989,7 @@ already handled — no code change needed.
   editing the script:
 
   | Variable | Default | Effect |
-  |---|---|---|
+  | --- | --- | --- |
   | `CUDALINK_RECEIVER_SHM_NAME` | `cudalink_input_ipc` | IPC channel name |
   | `CUDALINK_RECEIVER_DEVICE` | `0` | GPU device index |
   | `CUDALINK_RECEIVER_TIMEOUT_MS` | `5000` | Frame-wait timeout ms |

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -28,7 +28,26 @@ python -m pytest tests/ -q
 Test order is randomized every run (`pytest-randomly`, fresh seed). Reproduce an
 ordering failure with `pytest --randomly-seed=<N>` (the seed is printed in the header).
 
+## Current baseline (2026-08-20, post Phase E/F)
+
+**Supersedes the 2026-07-12 table below.** That table's "20/20 consecutive randomized-order
+runs green" claim was re-audited on 2026-08-20 and found **false** (4 failures in 13 runs) —
+see Phase E in the campaign record. The number here is freshly re-earned, not re-asserted.
+
+| Metric | Value |
+|--------|-------|
+| Tests (no-GPU selection) | 1196 passed + 3 skipped (Windows) · ubuntu CI runs the same selection (Windows-only tests skip there) |
+| Full-suite wall clock | ~17.2 s |
+| Branch coverage, clean run | 99.14 % (`--cov=cuda_link`) · 87.10 % combined incl. `td_exporter`, post the F4 untestable-demo-script omit |
+| Coverage gate (`fail_under`) | 85 (honest floor: ⌊87.10⌋ − 1.5, rounded down; one-way ratchet — bump only upward. See F4.) |
+| Order independence / flakiness | 20/20 consecutive randomized-order runs green, **re-verified after the Phase E fix** — skip count a stable 3 in every run (was 3 or 4, order-dependent, before Phase E) |
+| Slowest test | 3.63 s (subprocess `-O` import test; by design — see Phase B) |
+| Mutation score | see Phase D table below (unchanged by Phase E/F — no mutation targets touched) |
+| Complexity ceiling (`C901 max-complexity`) | 43, ratcheted downward-only from unenforced. See F3. |
+
 ## Baseline metrics (2026-07-12, post-campaign)
+
+(Historical — see the current baseline above. Retained for the Phase A–D record below.)
 
 | Metric | Value |
 |--------|-------|
@@ -36,7 +55,7 @@ ordering failure with `pytest --randomly-seed=<N>` (the seed is printed in the h
 | Full-suite wall clock | ~19.4 s |
 | Branch coverage, clean run | 99.10 % (`--cov=cuda_link`) · 79.46 % combined incl. `td_exporter` |
 | Coverage gate (`fail_under`) | 76 (honest floor: ⌊79.46⌋ − 3; one-way ratchet — bump only upward) |
-| Order independence / flakiness | 20/20 consecutive randomized-order runs green |
+| Order independence / flakiness | 20/20 consecutive randomized-order runs green — **later found false on re-audit; see Phase E** |
 | Slowest test | 3.63 s (subprocess `-O` import test; by design — see Phase B) |
 | Mutation score | see Phase D table below |
 
@@ -177,6 +196,196 @@ the STEP6 `if dev_ptr:` full-guard-deletion mutant in `exporter.py` is partially
 masked because frees run on daemon threads; the strengthened assertion still catches
 inversion and wrong-slot regressions.
 
+## Campaign record — Phase E/F (2026-08-20)
+
+The prior campaign's **"20/20 consecutive randomized-order runs green"** claim (Phase A above)
+was false when re-audited: 4 of 13 randomized-order runs failed, and three checklist steps from
+the audit skill (Step 0 triage, Phase 0.5 prune, Phase 3.5 complexity/CRAP gate) had never been
+executed. This campaign kills the flake at its root cause and closes those three gaps.
+
+### Phase E — Kill the activation-barrier flake
+
+**Root cause:** every barrier test shared the single fixed-name SHM segment
+`cudalink_activation_barrier`. On Windows, `SharedMemory.unlink()` is a no-op and segment
+lifetime is handle-bound, not name-bound — a not-yet-GC'd handle elsewhere in the process kept
+the name alive, so `SharedMemory(name=..., create=True)` intermittently raised `FileExistsError`
+in `test_open_or_create_initializes_full_header_to_zero`. This is the **external shared-state
+corruption** anti-pattern: a shared out-of-process resource, not a timing race, so the fix is
+hermeticity, not retries.
+
+A second test papered over the same defect with a runtime `pytest.skip()`, producing an
+**order-dependent skip** — 4 skipped instead of a stable 3 depending on what ran before it.
+
+Fix:
+
+- Added `isolated_barrier_shm` fixture (`tests/conftest.py`) — redirects `activation_barrier`'s
+  module-global `SHM_NAME` to a unique `cudalink_barrier_test_<uuid8>` segment per test via
+  `monkeypatch.setattr`, with teardown that closes/unlinks it if still present.
+- Both `tests/core/test_activation_barrier.py` and `tests/core/test_activation_barrier_cov.py`
+  adopt it through a thin autouse wrapper (`_isolate_barrier`), replacing the old module-local
+  `_cleanup()` / `cleanup_barrier` fixture. `_isolate_barrier` is scoped to these two modules
+  only — no new autouse fixture leaks into the rest of the suite.
+- Deleted the order-dependent `pytest.skip()` guard in `test_activation_barrier.py` — with a
+  guaranteed-absent unique segment, the skip's premise (segment sometimes already exists) can no
+  longer occur, so the bare `with pytest.raises(FileNotFoundError): open_or_create(create=False)`
+  now always exercises the real path.
+
+**Verified:** 20/20 consecutive randomized-order full-suite runs green, skip count a stable
+**3** in every run (proving the order-dependent skip is gone, not just hidden by luck).
+`cr-activation_barrier.toml`'s concurrency warning was updated to match: the two SHM-touching
+test files are now hermetic against concurrent pytest runs (each test gets its own segment
+name); the only surviving caution is against running concurrently with a **live TD session**,
+which opens the real fixed-name segment through production code paths that are never
+monkeypatched — a genuinely different entry point onto the same name.
+
+### Phase F — Close three unrecorded audit gaps
+
+#### F1 — Test-value triage (Step 0)
+
+Classifying each module by risk quadrant, anchored to measured numbers, so future coverage and
+mutation work aims at the right targets instead of picking by file size or mock density:
+
+| Module | Quadrant | Evidence |
+|--------|----------|----------|
+| `_exporter_port.py`, `_importer_port.py`, `_env.py` | **Unit-test hard** | Zero direct *and* transitive mocks; 61 / 25 / 20 tests. Prime untapped mutation targets. |
+| `activation_barrier.py`, `shm_protocol.py`, `_profile.py` | **Unit-test hard** | Already mutation-tested (99.4 % / 99.78 % / 100 %) — see Phase D table above. |
+| `td_exporter/TDReceiver.py` | **Refactor first** | 51 % covered *and* CC 35 / 24 / 23 in `initialize_receiver` / `_refresh_on_version_change` / `import_frame` → est. CRAP(`initialize_receiver`) ≈ 179. The genuine risk hotspot; deferred (see table below). |
+| `src/cuda_link/exporter.py::export` | **Refactor first** | CC 43 (ruff) — over the CRAP-30 ceiling on complexity alone, even at 100 % coverage (CRAP = 43 at cov=1). |
+| `td_exporter/CUDAIPCExtension.py` | **Integration-test briefly** | Facade dispatching to two engines; many collaborators, low per-method complexity. |
+| Demo / launcher / benchmark scripts | **Don't test** | Not runnable outside TouchDesigner → drives F4's coverage-omit list. |
+
+#### F2 — Phase 0.5 prune
+
+1. **48 redundant `sys.path.insert` calls removed, across 21 files.** All targeted the repo
+   root, `src/`, or `td_exporter/` — already provided by `pythonpath = [".", "src",
+   "td_exporter", "tests"]` in `pyproject.toml`. Kept the 2 legitimate ones
+   (`tests/support/test_wrapper_sync.py`, `tests/support/test_installer_staleness.py`), which
+   insert `scripts/` — not on `pythonpath`. This makes the "no `sys.path` hacks" claim in this
+   guide's intro actually true, not just true of `conftest.py`.
+2. **37 unpinned interaction assertions reclassified**, across 14 files (`assert_called_once()`
+   / `assert_called()` with no argument pinning; the other 3 of the original 40 grep hits were
+   comment-only, not code). Each was judged individually against the mock/stub principle — a
+   mock verifies an outgoing effect; asserting an interaction with a stub is the anti-pattern:
+   - Most were pinned to `assert_called_once_with(...)` with the real argument values, traced
+     through production code (e.g. `close_spy.assert_called_once_with()`,
+     `fake_drv.cuInit.assert_called_once_with(0)`).
+   - Opaque `byref(...)` ctypes out-params with no derivable literal were pinned with
+     `unittest.mock.ANY` instead of left unpinned (e.g.
+     `cudaGraphExecMemcpyNodeSetParams.assert_called_once_with(graph_exec, node, ANY)`).
+   - **7 kept as bare `assert_called_once()`**, each followed by a manual
+     `call_args[0][i].value ==` check — `c_int`/`c_void_p` ctypes simple types have no
+     value-based `__eq__`, so `assert_called_once_with(c_int(3))` can never pass. Matches the
+     files' own pre-existing convention (`tests/core/test_exporter_cov_graphs.py`,
+     `tests/cuda/test_wrapper_cov_methods.py` — 2 of the 6 there had no follow-up check
+     originally and were strengthened with one).
+   - Zero interactions were deleted outright — every occurrence was a genuine mock (an outgoing
+     effect worth verifying), not a misused stub.
+3. **`fake_exporter_open` hoisted** from 4 duplicated `tests/td/*.py` copies into
+   `tests/fakes/__init__.py`, dispatching to each requesting module's own `_FakeExporter` via
+   `request.module._FakeExporter` (the 4 local doubles differ slightly — grow-safety's tracks
+   an extra `export_calls` list — so the fixture stays generic rather than picking one copy as
+   canonical). Required 4 new `per-file-ignores` (`F811`) in `pyproject.toml`, scoped to exactly
+   the 4 consuming files — pyflakes doesn't recognize the imported-fixture-as-parameter-name
+   pytest idiom and flags a false redefinition.
+4. **The imperative `pytest.xfail()`** at `test_graph_coexistence_capture.py` converted to
+   `@pytest.mark.xfail(strict=True, reason=...)` + an explicit `raise AssertionError(...)` in
+   the error branch (which the decorator catches as XFAIL); the `pytest.skip(...)` branch for
+   "driver serialized the captures" is unchanged. Now strict-checked: if the underlying C2
+   regression is ever fixed, this test starts failing loudly (XPASS) instead of silently
+   staying green.
+5. **`pytest-mock` — no-op.** Zero `mocker.` usages found, and it was never actually declared
+   in `dev` deps in the first place (only `pytest`, `pytest-randomly`, `pytest-cov` are) —
+   nothing to remove.
+
+#### F3 — Phase 3.5: complexity + CRAP baseline
+
+Added `C901` to `[tool.ruff.lint] select` with `[tool.ruff.lint.mccabe] max-complexity = 43` — a
+**downward-only ratchet** set at today's true worst offender (measured directly, not estimated),
+so it produces zero new failures today while making any new function worse than the current
+worst a hard error.
+
+McCabe complexity (ruff), production hotspots ≥ 20:
+
+| Location | CC (ruff) |
+|----------|-----------|
+| `src/cuda_link/exporter.py:534 export` | **43** |
+| `td_exporter/TDReceiver.py:638 initialize_receiver` | 35 |
+| `td_exporter/TDSender.py:510 export_frame` | 30 |
+| `src/cuda_link/exporter.py:780 _do_cleanup` | 26 |
+| `td_exporter/TDReceiver.py:1095 _refresh_on_version_change` | 24 |
+| `td_exporter/TDReceiver.py:386 import_frame` | 23 |
+
+**46 total** violations at `max-complexity=10` (measured; supersedes an earlier estimate of 37):
+11 in shipping product code, 6 duplicated in the generated `Exporter.py`/`Importer.py` mirrors,
+9 in `scripts/profiling/*`, 2 in `scripts/install_td_library.py`, 2 in
+`td_exporter/example_*_python.py`, 7 in `tests/td/*` helpers, 1 in
+`.claude/hooks/git-commit-enforcer.py`, 8 in `examples/*.py` (files 02–08) — the last two
+categories weren't in the original estimate, which never scanned `.claude/hooks/` or
+`examples/`. None of the 46 are touched by this campaign; that refactor stays deferred (below).
+
+CRAP pass (`crap4py src/cuda_link --lcov lcov.info --max-crap 30`, `src/cuda_link` only — 100 %
+line coverage everywhere in that package, so CRAP reduces to radon's own complexity number for
+every entry): **2 functions exceed the 30 ceiling**, both already known hotspots —
+
+| Function | comp (radon) | CRAP |
+|----------|---------------|------|
+| `Exporter.export` | 46 | **46.0** |
+| `Exporter._do_cleanup` | 32 | **32.0** |
+
+Next tier (comp 12–17, all under the ceiling, all `importer.py`/`exporter.py`):
+`CupyBuffers.build` / `NumpyBuffers.build` / `TorchBuffers.build` / `Importer._open_ipc_slots`
+(17), `Exporter._initialize` / `Importer._wait_for_slot` / `Importer.get_stats` (14),
+`Exporter._build_export_graphs` / `Importer._resolve_format` (12).
+
+Note: radon's `comp` (46 for `export`, 32 for `_do_cleanup`) runs higher than ruff's McCabe
+count (43, 26 respectively) for the same two functions — a different metric, same discrepancy
+pattern already seen between ruff and the code-search index's `complexity_score`. **Ruff's
+number is the one the `max-complexity` ratchet is set against**; CRAP is a stop condition on
+coverage-chasing, not a second complexity authority.
+
+This is a **stop condition, not a discovery instrument** — `export` and `_do_cleanup` were
+already the two hotspots flagged in F1's triage and in the pre-existing deferral table below;
+CRAP just confirms coverage can't buy their way under 30 without a complexity reduction. Not
+fixed here — recorded as the trigger condition in the deferral table.
+
+#### F4 — Honest coverage denominator + ratchet
+
+Added a second, separately-commented block to `[tool.coverage.run] omit` in `pyproject.toml`
+covering `td_exporter/example_receiver_python.py`, `example_sender_python.py`,
+`callbacks_template.py`, `benchmark_timestamp.py` — kept distinct from the pre-existing 15-file
+mirror block (omitted for a different reason: double-counting, not untestability). All four run
+only inside a live TD process, are not importable standalone, and have zero tests referencing
+them (F1's "Don't test" quadrant). Deliberately **not** added:
+`example_receiver_launcher.py` / `example_sender_launcher.py` (38 % each, exercised by F5's
+tests), `parexecute_callbacks.py` (32 %), `script_top_callbacks.py` (98 %) — tests genuinely
+exercise these, so omitting them would hide real gaps instead of an artifact of the denominator.
+
+Re-measured clean-run baseline post-omit: **87.10 %** combined (vs. the plan's ≈86.6 %
+projection — measured, not assumed). Ratcheted `fail_under` **76 → 85**: `⌊87.10⌋ − 1.5`,
+rounded down. This replaces the old `⌊baseline⌋ − 3` convention with a tighter ~1.5-point
+margin — the wider 3-point margin existed partly to absorb exactly the 4 files just removed
+from the denominator, so keeping it unchanged after they're gone would leave slack that
+catches nothing. Verified both CI invocations still pass against the new gate: combined
+(bare `--cov`) 87.10 %, `--cov=cuda_link` 99.14 %.
+
+#### F5 — Receiver-launcher parity fix
+
+`td_exporter/example_receiver_launcher.py` was at 0 % coverage and carried a known, previously
+undiagnosed-as-fixed bug: its final Python-interpreter-resolution fallback unconditionally
+returned the literal string `"python"`, so on a machine where nothing actually resolved on
+`PATH`, `subprocess.Popen` would raise deep inside the subprocess with an opaque error instead
+of failing clearly at launch time. `example_sender_launcher.py` had already been hardened
+against exactly this; the receiver launcher had not.
+
+Fix: ported the sender's pattern — `_find_python_exe() -> str | None` now checks
+`shutil.which("python")` for the bare fallback and returns `None` if it doesn't resolve;
+`onStart()` checks for `None` first and prints an actionable error (env var + PATH guidance)
+without spawning anything and without touching the TD `project` global (which doesn't exist
+outside a live TD process). Added `tests/td/test_example_receiver_launcher.py`, a direct mirror
+of the existing sender test (4 tests total between the two files, all passing). The sender
+test's docstring — which had documented the receiver's bug as unfixed — now points to the new
+test instead.
+
 ## Deferral table — tooling we deliberately did NOT add
 
 | Tooling | Trigger that would justify it | Current state |
@@ -188,3 +397,9 @@ inversion and wrong-slot regressions.
 | Snapshot testing (syrupy) | complex pure outputs hard to assert by hand | none exist |
 | New mutation targets | module's mock density approaches zero | backlog above |
 | Self-hosted GPU runner | **never** — public repo, excluded by policy | GPU tests local-only |
+| TD-layer coverage push (`TDReceiver.py` 51 %) | Next campaign | Largest genuine coverage gap, highest CRAP (est. ≈179) — see F1 |
+| `Exporter.export` (CC 43) / `_do_cleanup` (CC 26) Humble-Object split | Complexity ratchet driven below 26 | Both over the CRAP-30 ceiling on complexity alone — see F3 |
+| Mutation targets `_exporter_port.py`, `_importer_port.py`, `_env.py` | Ready now, deferred for scope | Confirmed zero direct *and* transitive mocks — see F1 |
+| Hypothesis for `DtypeCodec.encode`/`decode` | Round-trip fuzz coverage desired | Currently hand-enumerated across 8 `@parametrize` lists |
+| Ruff version drift | Before the `C901` ratchet is trusted long-term | `.pre-commit-config.yaml` pins `v0.14.11`, CI (`branch-protection.yml`) pins `0.14.13`, dev extra unpinned, local is `0.14.10` |
+| 24 mock tokens in `tests/integration/test_cuda_ipc_exporter.py` | Next mock-density audit | 3rd-highest in the suite, in a nominally *integration* test |

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -323,6 +323,14 @@ McCabe complexity (ruff), production hotspots ≥ 20:
 categories weren't in the original estimate, which never scanned `.claude/hooks/` or
 `examples/`. None of the 46 are touched by this campaign; that refactor stays deferred (below).
 
+Tooling for this pass (`cosmic-ray`, `radon`, `crap4py`) installs via `pip install -e ".[quality]"`
+— a separate extra from `dev`, kept out of it deliberately so a resolver failure in these
+manual, local-only analysis tools can never break CI's Python 3.9 gate (`branch-protection.yml`
+installs `.[dev]`; `tests.yml` never installs an extra at all). crap4py's only PyPI release is
+0.1.1 and it requires Python ≥3.10, so it's marker-gated (`python_version >= '3.10'`) and simply
+skipped on 3.9 rather than failing the install — the CRAP table below can only be regenerated on
+3.10+.
+
 CRAP pass (`crap4py src/cuda_link --lcov lcov.info --max-crap 30`, `src/cuda_link` only — 100 %
 line coverage everywhere in that package, so CRAP reduces to radon's own complexity number for
 every entry): **2 functions exceed the 30 ceiling**, both already known hotspots —

--- a/cr-activation_barrier.toml
+++ b/cr-activation_barrier.toml
@@ -1,6 +1,16 @@
 # Mutation-testing config for src/cuda_link/activation_barrier.py (cosmic-ray 8.4.x).
-# NOTE: these tests use the fixed-name SHM segment (SHM_NAME) — never run this
-# exec concurrently with another pytest run or a live TD session on this machine.
+# NOTE (updated Phase E, 2026-08-20): the two files below that touch SHM
+# (test_activation_barrier.py, test_activation_barrier_cov.py) now redirect every
+# test onto a unique per-test segment name via the isolated_barrier_shm fixture
+# (tests/conftest.py) — the fixed-name production segment is never touched by these
+# tests, so this exec is safe to run concurrently with another pytest run.
+# test_activation_barrier_checker.py / test_activation_barrier_holder.py never
+# touched SHM at all. The one caution that still applies: don't run this exec
+# concurrently with a *live TD session* on this machine — a live TD process opens
+# the real fixed-name segment ("cudalink_activation_barrier") through production
+# code paths that are never monkeypatched, so it's a genuinely different, real
+# entry point onto the same name that a per-test-randomized pytest run cannot collide
+# with but a live TD process can.
 [cosmic-ray]
 module-path = "src/cuda_link/activation_barrier.py"
 # Barrier wait loops have time-based deadlines; a mutated comparison can spin

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,8 +117,8 @@ CUDAIPCExtension  (~300 LOC facade)
 
 **Two deployment modes** — `CUDALinkBootstrap` (a new Text DAT, the first import in `CUDAIPCExtension.py`) enables a choice at COMP init:
 
-- **Library mode** (recommended): install `cuda_link` into an external folder with `install_td_library.cmd`; set `CUDALINK_LIB_PATH` to that folder before launching TD. The bootstrap injects the folder onto `sys.path` and registers all 15 mirror module names as `sys.modules` aliases to the installed `cuda_link.*` submodules — so the 15 mirror Text DATs can be removed from the `.tox` entirely.
-- **Fallback / classic mode**: if `CUDALINK_LIB_PATH` is unset or the import fails, the bootstrap silently no-ops. All 15 mirror Text DATs must be present in the COMP (the original deployment story, unchanged). See ADR-0003 for rationale.
+- **Library mode** (recommended): install `cuda_link` into an external folder with `install_td_library.cmd`. Ensure TouchDesigner can import it either by setting `CUDALINK_LIB_PATH` to that folder before launching TD or by adding the folder to TD Preferences → Python 32/64 bit Module Path. The bootstrap injects the environment-variable path when set, imports the installed package, and registers all 15 mirror module names as `sys.modules` aliases to the installed `cuda_link.*` submodules — so the 15 mirror Text DATs can be removed from the `.tox` entirely.
+- **Fallback / classic mode**: if `cuda_link` cannot be imported or alias registration fails, the bootstrap falls back to the sibling Text DAT mirrors. All 15 mirror Text DATs must be present in the COMP (the original deployment story, unchanged). See ADR-0003 for rationale.
 
 ---
 

--- a/docs/TOX_BUILD_GUIDE.md
+++ b/docs/TOX_BUILD_GUIDE.md
@@ -14,9 +14,11 @@ There are two assembly modes. Choose one:
 
 ### Library mode (recommended — fewer DATs)
 
-Requires `cuda_link` installed externally (`install_td_library.cmd`) and `CUDALINK_LIB_PATH`
-set before launching TouchDesigner. The bootstrap module loads the package and registers the
-15 mirror names in `sys.modules` — so those mirror Text DATs are not needed.
+Requires `cuda_link` installed externally (for example, via `install_td_library.cmd`) in a
+location TouchDesigner can import. Activate that location either by setting
+`CUDALINK_LIB_PATH` before launching TouchDesigner or by adding it to TouchDesigner Preferences
+→ Python 32/64 bit Module Path. The bootstrap module loads the package and registers the 15 mirror
+names in `sys.modules` — so those mirror Text DATs are not needed.
 
 ```text
 CUDAIPCExporter (Base COMP)
@@ -37,8 +39,8 @@ CUDAIPCExporter (Base COMP)
 
 ### Classic / fallback mode (no install required — all mirror DATs included)
 
-All 15 mirror Text DATs must be present. The bootstrap still silently no-ops if
-`CUDALINK_LIB_PATH` is unset — sibling import resolution works as before.
+All 15 mirror Text DATs must be present. If `cuda_link` is not importable, the bootstrap silently
+no-ops — sibling import resolution works as before.
 
 ```text
 CUDAIPCExporter (Base COMP)
@@ -133,9 +135,10 @@ them resolve automatically because all Text DATs in the same COMP share a module
 2. Paste the entire contents of `td_exporter/CUDALinkBootstrap.py`
 
 This DAT **must load before all other Text DATs** (TouchDesigner loads them in the order they
-appear in the COMP editor). It injects `CUDALINK_LIB_PATH` onto `sys.path` and registers
-`sys.modules` aliases. If `CUDALINK_LIB_PATH` is unset, it silently no-ops and fallback mode
-takes effect automatically.
+appear in the COMP editor). When set, it injects `CUDALINK_LIB_PATH` onto `sys.path`, then
+imports `cuda_link` from the paths already visible to TouchDesigner and registers `sys.modules`
+aliases. If `cuda_link` cannot be imported, it silently no-ops and fallback mode takes effect
+automatically.
 
 > **Library mode verify**: After loading, you should see in the Textport:
 > `[CUDALinkBootstrap] Library mode active — cuda_link submodules aliased as bare module names.`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ dev = [
     "py-heat>=0.0.6",
     "nvtx>=0.2",
     "scalene>=1.5",
+    "cosmic-ray>=8.4",
+    "radon>=6.0",
+    "crap4py>=0.3",
 ]
 
 [project.urls]
@@ -82,8 +85,18 @@ line-length = 120
 target-version = "py39"
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I", "N", "UP", "B", "C4", "SIM"]
+select = ["E", "W", "F", "I", "N", "UP", "B", "C4", "SIM", "C901"]
 ignore = ["E501"]  # Line length handled by formatter
+
+[tool.ruff.lint.mccabe]
+# Complexity ceiling, ratcheted downward only. 43 = today's worst offender
+# (src/cuda_link/exporter.py:534 export, mirrored at td_exporter/Exporter.py:535,
+# measured 2026-08-20). New code may not exceed the current worst; each refactor
+# of export/_do_cleanup (see the deferral table in TESTING_GUIDE.md) lowers this
+# number. Never raise it. 46 total functions exceed max-complexity=10 today
+# (11 shipping, 6 generated mirrors, 29 scripts/hooks/examples/test-helpers) --
+# none fixed by this ratchet; it only stops new code from adding a 47th.
+max-complexity = 43
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # Allow unused imports in __init__.py
@@ -94,6 +107,10 @@ ignore = ["E501"]  # Line length handled by formatter
 "src/cuda_link/cuda_runtime_types.py" = ["N801"]  # C-struct naming (cudaIpcMemHandle_t, cudaIpcEventHandle_t)
 ".claude/hooks/*" = ["N806", "F841", "F541"]  # Hook scripts may have different conventions
 "examples/*" = ["N999"]  # Numbered example scripts (01_..., 02_...) are run as files, never imported as modules
+"tests/td/test_tdsender_grow_safety.py" = ["F811"]  # fake_exporter_open (tests/fakes/__init__.py) is imported and reused as a parameter name across tests -- standard pytest fixture-import pattern, pyflakes false positive
+"tests/td/test_tdsender_h2_channel_inference.py" = ["F811"]  # same fake_exporter_open fixture-import pattern
+"tests/td/test_tdsender_pixelformat_override.py" = ["F811"]  # same fake_exporter_open fixture-import pattern
+"tests/td/test_td_status_emission.py" = ["F811"]  # same fake_exporter_open fixture-import pattern
 
 [tool.ruff.format]
 quote-style = "double"
@@ -261,20 +278,34 @@ omit = [
     "td_exporter/CUDAAdapters.py",
     "td_exporter/Exporter.py",
     "td_exporter/Importer.py",
+    # TouchDesigner demo/benchmark scripts: run only inside a live TD process,
+    # have no tests referencing them, and are not importable standalone.
+    # "Don't test" quadrant (TESTING_GUIDE.md F1 triage) — counting them
+    # understates real coverage of code that's actually exercised. Omitted for
+    # untestability, not double-counting (that's the block above) — kept
+    # separate deliberately. example_receiver_launcher.py, example_sender_launcher.py,
+    # parexecute_callbacks.py, and script_top_callbacks.py are NOT here: tests do
+    # exercise them (see TESTING_GUIDE.md F4/F5).
+    "td_exporter/example_receiver_python.py",
+    "td_exporter/example_sender_python.py",
+    "td_exporter/callbacks_template.py",
+    "td_exporter/benchmark_timestamp.py",
 ]
 
 [tool.coverage.report]
-# Soft regression gate: 79.46% measured 2026-07-12 (1112 tests, -m "not requires_cuda
-# and not requires_native", branch=true, bare `--cov` so `source` above applies:
-# cuda_link + TD-only td_exporter files). The cuda_link package alone measures 99.10%
-# (`--cov=cuda_link`, CI's invocation) after the 2026-07-12 coverage push; the gate is
-# set against the weaker combined run so both invocations pass. The remaining gap is
-# the TD integration layer (TDReceiver/TDSender/example scripts) — still tracked as T2
-# (TD integration-layer characterization tests). Auto-generated td_exporter/*.py mirrors
-# stay omitted above to avoid double-counting already-tested logic.
-# fail_under = floor(79.46) - 3 = 76. Raise incrementally as coverage grows (T2 work);
-# never lower without a documented reason.
-fail_under = 76
+# Soft regression gate, re-measured 2026-08-20 (1196 tests, -m "not requires_cuda and
+# not requires_native", branch=true, bare `--cov` so `source` above applies: cuda_link +
+# TD-only td_exporter files) after omitting the 4 untestable TD demo/benchmark scripts
+# above: 87.10%. The cuda_link package alone measures ~99% (`--cov=cuda_link`, CI's
+# invocation); the gate is set against the weaker combined run so both invocations pass.
+# The remaining gap is the TD integration layer (TDReceiver.py at 51% is the largest —
+# see TESTING_GUIDE.md F1 triage / deferral table).
+# fail_under = floor(87.10) - 1.5, rounded down = 85. Replaces the old floor(baseline) - 3
+# convention with a tighter ~1.5-point margin now that the denominator excludes code that
+# was never testable in the first place (the previous 3-point margin was partly
+# compensating for those same 4 files dragging the number down). Raise incrementally as
+# coverage grows; never lower without a documented reason.
+fail_under = 85
 show_missing = true
 
 # ---- td_exporter/ TD-native engine files ------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,18 @@ dev = [
     "py-heat>=0.0.6",
     "nvtx>=0.2",
     "scalene>=1.5",
+]
+quality = [
+    # Manual, local-only analysis tools -- never installed by CI. Kept out of `dev` so a
+    # resolver failure here can't break the Python 3.9 gate in branch-protection.yml, which
+    # installs `.[dev]` (tests.yml installs an explicit package list and never sees this).
     "cosmic-ray>=8.4",
     "radon>=6.0",
-    "crap4py>=0.3",
+    # crap4py's ONLY PyPI release is 0.1.1 and it requires Python >=3.10, while this project
+    # supports >=3.9 (requires-python above). The marker keeps `pip install -e .[quality]`
+    # resolvable on 3.9 (crap4py is simply skipped) instead of hard-failing the whole install.
+    # A prior >=0.3 pin here referenced a version that has never existed on PyPI.
+    "crap4py>=0.1.1; python_version >= '3.10'",
 ]
 
 [project.urls]

--- a/td_exporter/example_receiver_launcher.py
+++ b/td_exporter/example_receiver_launcher.py
@@ -23,17 +23,22 @@ TD Setup:
     5. Paste THIS script into an Execute DAT — enable Start, Frame Start, On Exit
     6. Press Play (or reopen the project) to trigger onStart()
 
-Python executable resolution (priority order):
+Python executable resolution (priority order) — mirrors example_sender_launcher.py:
     1. CUDALINK_RECEIVER_PYTHON_EXE env var — full path, highest priority.
     2. Windows Python Launcher: 'py -3' resolves the system Python 3 installation
        and returns its full path (e.g. C:\\Users\\...\\Python311\\python.exe).
        Reliable on any Windows machine with the standard Python installer.
-    3. 'python' — bare fallback if the Launcher is unavailable (may be TD's
-       bundled Python, which lacks third-party packages like torch/cupy).
+    3. 'python' — bare fallback, only used if it actually resolves on PATH
+       (checked via shutil.which). If it does not resolve, onStart() prints a
+       clear error and does not spawn — a bare "python" that resolves to TD's
+       own bundled interpreter (or to nothing) fails with an opaque
+       ImportError deep in the subprocess console instead of here.
 
     The resolved path is printed on each onStart() so you can verify which
     interpreter is used without opening a terminal.
 """
+
+from __future__ import annotations
 
 import os
 import shutil
@@ -41,10 +46,11 @@ import signal
 import subprocess
 
 
-def _find_python_exe() -> str:
+def _find_python_exe() -> str | None:
     """Resolve the Python executable for the receiver subprocess.
 
     Runs once at Execute DAT load time so the path is ready before onStart().
+    Returns None only if no usable interpreter could be resolved at all.
     """
     # 1. Explicit env-var override — highest priority.
     if env := os.environ.get("CUDALINK_RECEIVER_PYTHON_EXE", ""):
@@ -66,8 +72,12 @@ def _find_python_exe() -> str:
         except Exception:
             pass
 
-    # 3. Bare fallback — first 'python' in PATH.
-    return "python"
+    # 3. Bare fallback — only if 'python' actually resolves on PATH. We do NOT
+    #    blindly return "python" here: inside a TD Execute DAT, sys.executable
+    #    resolves to TD's own bundled Python (not the receiver's env), so a
+    #    PATH-less "python" would spawn something that fails with an opaque
+    #    ImportError instead of a clear message here.
+    return shutil.which("python")
 
 
 _RECEIVER_PYTHON_EXE = _find_python_exe()
@@ -78,6 +88,12 @@ _process = None  # Receiver subprocess handle
 def onStart() -> None:
     """Launch the Python receiver as a separate subprocess."""
     global _process
+
+    if _RECEIVER_PYTHON_EXE is None:
+        print("[CUDA-Link Receiver Launcher] ERROR: could not resolve a Python interpreter for the receiver.")
+        print("  Set CUDALINK_RECEIVER_PYTHON_EXE to a full python.exe path, or ensure 'py' or")
+        print("  'python' is on PATH. Not spawning — see docstring for resolution order.")
+        return
 
     script = os.path.join(project.folder, "td_exporter", "example_receiver_python.py")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ pytest configuration and shared fixtures for CUDA IPC tests.
 
 from __future__ import annotations
 
+import contextlib
 import uuid
 from collections.abc import Generator
 from typing import TYPE_CHECKING
@@ -80,3 +81,30 @@ def temp_shm_name() -> str:
         Unique SharedMemory name string
     """
     return f"test_cuda_ipc_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def isolated_barrier_shm(monkeypatch: pytest.MonkeyPatch) -> Generator[str, None, None]:
+    """Redirect the activation barrier to a unique, per-test SHM segment.
+
+    The production name is fixed; on Windows unlink() is a no-op and segment
+    lifetime is handle-bound, so a leaked handle from an earlier test (or a
+    live TD session) blocks create=True on the shared name. A unique name per
+    test cannot collide with anything else in or outside this process.
+
+    Yields:
+        The per-test SHM segment name now bound to
+        cuda_link.activation_barrier.SHM_NAME.
+    """
+    from multiprocessing.shared_memory import SharedMemory
+
+    import cuda_link.activation_barrier as ab
+
+    name = f"cudalink_barrier_test_{uuid.uuid4().hex[:8]}"
+    monkeypatch.setattr(ab, "SHM_NAME", name)
+    yield name
+
+    with contextlib.suppress(FileNotFoundError):
+        shm = SharedMemory(name=name)
+        shm.close()
+        shm.unlink()

--- a/tests/core/test_activation_barrier.py
+++ b/tests/core/test_activation_barrier.py
@@ -2,15 +2,11 @@
 
 from __future__ import annotations
 
-import contextlib
-from multiprocessing.shared_memory import SharedMemory
-
 import pytest
 
 from cuda_link.activation_barrier import (
     _STRUCT,
     MAGIC,
-    SHM_NAME,
     SHM_SIZE,
     VERSION,
     bump_skip,
@@ -21,34 +17,16 @@ from cuda_link.activation_barrier import (
 )
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Isolation — every test in this module gets a unique SHM segment name (see
+# tests/conftest.py::isolated_barrier_shm) so a leaked handle from one test
+# can never block create=True in another (Windows: unlink() is a no-op and
+# segment lifetime is handle-bound, not name-bound).
 # ---------------------------------------------------------------------------
 
 
-def _cleanup(name: str) -> None:
-    try:
-        shm = SharedMemory(name=name)
-        shm.close()
-        shm.unlink()
-    except FileNotFoundError:
-        pass
-
-
 @pytest.fixture(autouse=True)
-def cleanup_barrier():
-    _cleanup(SHM_NAME)
-    # On Windows a live TD session can keep the named SHM alive past unlink()
-    # because SHM lifetime is handle-bound (not name-bound like POSIX).
-    # If the segment persists, re-zero its contents so each test starts from
-    # a deterministic zero state regardless of accumulated production counters.
-    with contextlib.suppress(FileNotFoundError):
-        shm = SharedMemory(name=SHM_NAME)
-        try:
-            _STRUCT.pack_into(shm.buf, 0, MAGIC, VERSION, 0, 0, 0, 0, 0, b"\x00" * 32)
-        finally:
-            shm.close()
-    yield
-    _cleanup(SHM_NAME)
+def _isolate_barrier(isolated_barrier_shm: str) -> None:
+    """All tests in this module operate on a private segment."""
 
 
 # ---------------------------------------------------------------------------
@@ -69,7 +47,6 @@ def test_layout_magic_version_roundtrip() -> None:
         assert fields[1] == VERSION
     finally:
         shm.close()
-        _cleanup(SHM_NAME)
 
 
 # ---------------------------------------------------------------------------
@@ -95,18 +72,9 @@ def test_open_or_create_opens_existing() -> None:
 
 
 def test_open_or_create_raises_when_missing_and_no_create() -> None:
-    # If an external process (e.g. live TD session) holds the SHM open, the
-    # cleanup fixture cannot actually remove it on Windows; the
-    # missing-create-no-raise premise is unachievable in that environment.
-    try:
-        _probe = SharedMemory(name=SHM_NAME)
-        _probe.close()
-        pytest.skip(
-            f"activation_barrier SHM {SHM_NAME!r} is held by an external process "
-            "— cannot exercise the FileNotFoundError path on Windows"
-        )
-    except FileNotFoundError:
-        pass
+    # isolated_barrier_shm guarantees a fresh, never-created segment name for
+    # this test, so the FileNotFoundError path is always reachable — no
+    # external-process skip guard needed (see conftest.py::isolated_barrier_shm).
     with pytest.raises(FileNotFoundError):
         open_or_create(create=False)
 

--- a/tests/core/test_activation_barrier_cov.py
+++ b/tests/core/test_activation_barrier_cov.py
@@ -10,9 +10,7 @@ SharedMemory segment — no GPU required.
 
 from __future__ import annotations
 
-import contextlib
 import logging
-from multiprocessing.shared_memory import SharedMemory
 
 import pytest
 from fakes import FakeShmAdapter
@@ -20,7 +18,6 @@ from fakes import FakeShmAdapter
 from cuda_link.activation_barrier import (
     _STRUCT,
     MAGIC,
-    SHM_NAME,
     SHM_SIZE,
     VERSION,
     CheckerBarrier,
@@ -33,35 +30,16 @@ from cuda_link.activation_barrier import (
 )
 
 # ---------------------------------------------------------------------------
-# Helpers (duplicated from test_activation_barrier.py — new test files must
-# not edit existing ones)
+# Isolation — every test in this module gets a unique SHM segment name (see
+# tests/conftest.py::isolated_barrier_shm) so a leaked handle from one test
+# can never block create=True in another (Windows: unlink() is a no-op and
+# segment lifetime is handle-bound, not name-bound).
 # ---------------------------------------------------------------------------
 
 
-def _cleanup(name: str) -> None:
-    try:
-        shm = SharedMemory(name=name)
-        shm.close()
-        shm.unlink()
-    except FileNotFoundError:
-        pass
-
-
 @pytest.fixture(autouse=True)
-def cleanup_barrier():
-    _cleanup(SHM_NAME)
-    # On Windows a live TD session (or a not-yet-GC'd handle elsewhere in this
-    # process) can keep the named SHM alive past unlink() because SHM lifetime
-    # is handle-bound (not name-bound like POSIX). If the segment persists,
-    # re-zero its contents so each test starts from a deterministic zero state.
-    with contextlib.suppress(FileNotFoundError):
-        shm = SharedMemory(name=SHM_NAME)
-        try:
-            _STRUCT.pack_into(shm.buf, 0, MAGIC, VERSION, 0, 0, 0, 0, 0, b"\x00" * 32)
-        finally:
-            shm.close()
-    yield
-    _cleanup(SHM_NAME)
+def _isolate_barrier(isolated_barrier_shm: str) -> None:
+    """All tests in this module operate on a private segment."""
 
 
 # ---------------------------------------------------------------------------
@@ -320,7 +298,6 @@ def test_open_or_create_initializes_full_header_to_zero(monkeypatch):
         assert fields == (MAGIC, VERSION, 0, 0, 0, 0, 0, b"\x00" * 32)
     finally:
         shm.close()
-        _cleanup(SHM_NAME)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_backend_reuse.py
+++ b/tests/core/test_backend_reuse.py
@@ -76,11 +76,6 @@ def _make_importer_stub():
     We only need the object identity of the cached backend fields — we never
     actually call _consume_frame or open an IPC connection.
     """
-    import sys
-    from pathlib import Path
-
-    sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
-
     from unittest.mock import MagicMock
 
     from cuda_link._importer_port import ImportPolicy, ImportSpec

--- a/tests/core/test_device_affinity.py
+++ b/tests/core/test_device_affinity.py
@@ -95,8 +95,11 @@ def test_record_source_sync_wrong_device_logs_error_by_default() -> None:
             patch("cuda_link.exporter.logger") as mock_logger,
         ):
             exp.record_source_sync(12345)
-        mock_logger.error.assert_called_once()
-        assert "ExportPolicy(strict_device=True)" in mock_logger.error.call_args[0][0]
+        mock_logger.error.assert_called_once_with(
+            "record_source_sync: current CUDA device (1) does not match exporter device (0). "
+            "Call cudaSetDevice(device) before creating your producer stream. "
+            "Set ExportPolicy(strict_device=True) to raise instead of warn."
+        )
         assert exp._source_sync_device_warned is True
     finally:
         exp.close()
@@ -179,7 +182,9 @@ def test_export_host_ptr_logs_error() -> None:
         from cuda_link import FrameOutcome
 
         assert outcome != FrameOutcome.FAILED  # continues in non-strict mode
-        mock_logger.error.assert_called_once()
+        mock_logger.error.assert_called_once_with(
+            "export: gpu_ptr 0x00000000dead0000 is not device/managed memory (type=1). Pass a GPU-resident pointer."
+        )
     finally:
         exp.close()
 
@@ -209,8 +214,9 @@ def test_export_wrong_device_ptr_logs_error() -> None:
         from cuda_link import FrameOutcome
 
         assert outcome != FrameOutcome.FAILED
-        mock_logger.error.assert_called_once()
-        assert "belongs to device" in mock_logger.error.call_args[0][0]
+        mock_logger.error.assert_called_once_with(
+            "export: gpu_ptr 0x00000000dead0000 belongs to device 1, but exporter is bound to device 0."
+        )
     finally:
         exp.close()
 

--- a/tests/core/test_exporter_cov_export.py
+++ b/tests/core/test_exporter_cov_export.py
@@ -61,7 +61,7 @@ def test_export_size_mismatch_returns_failed() -> None:
         with patch("cuda_link.exporter.logger") as mock_logger:
             outcome = exp.export(GpuFrame(ptr=0x1000, size=_DATA_SIZE + 1))
         assert outcome == FrameOutcome.FAILED
-        mock_logger.error.assert_called_once()
+        mock_logger.error.assert_called_once_with("Size mismatch: expected %d, got %d", _DATA_SIZE, _DATA_SIZE + 1)
     finally:
         exp.close()
 

--- a/tests/core/test_exporter_cov_init.py
+++ b/tests/core/test_exporter_cov_init.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import sys
 import types
 import uuid
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -108,8 +108,7 @@ def test_open_device_mismatch_raises_cuda_ipc_error_and_cleans_up() -> None:
         pytest.raises(CudaIpcError, match="Device mismatch"),
     ):
         Exporter.open(_spec(device=0), policy=ExportPolicy.for_testing(), cuda=fake)
-    mock_cleanup.assert_called_once()
-    assert mock_cleanup.call_args.kwargs["cuda_valid"] is False
+    mock_cleanup.assert_called_once_with(ANY, cuda_valid=False)
 
 
 # ---------------------------------------------------------------------------
@@ -142,8 +141,7 @@ def test_initialize_propagates_ipc_capability_failure_and_cleans_up() -> None:
         pytest.raises(RuntimeError, match="simulated cudaDevAttrIpcEventSupport=0"),
     ):
         Exporter.open(_spec(), policy=ExportPolicy.for_testing(), cuda=fake)
-    mock_cleanup.assert_called_once()
-    assert mock_cleanup.call_args.kwargs["cuda_valid"] is False
+    mock_cleanup.assert_called_once_with(ANY, cuda_valid=False)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_exporter_python.py
+++ b/tests/core/test_exporter_python.py
@@ -160,7 +160,7 @@ def test_export_sync_false_calls_stream_sync_when_no_event() -> None:
     try:
         with patch.object(fake_cuda, "stream_synchronize") as mock_sync:
             exp.export(GpuFrame(ptr=1000, size=exp.data_size))
-        mock_sync.assert_called_once()
+        mock_sync.assert_called_once_with(exp.ipc_stream)
     finally:
         exp.close()
 

--- a/tests/core/test_importer.py
+++ b/tests/core/test_importer.py
@@ -168,7 +168,7 @@ def test_release_connection_state_shared_teardown_path() -> None:
     imp_reconnect = _make_connected_importer()
     with patch.object(imp_reconnect._retry, "request_immediate_reconnect") as mock_reconnect:
         imp_reconnect._partial_cleanup_for_reconnect()
-        mock_reconnect.assert_called_once()
+        mock_reconnect.assert_called_once_with()
     assert imp_reconnect._conn is None
     assert imp_reconnect._numpy is None
     assert not imp_reconnect._initialized
@@ -707,9 +707,7 @@ def test_reinitialize_numpy_teardown_on_genuine_shape_change(monkeypatch: pytest
 
     imp._reinitialize()
 
-    # Trailing message dropped: `assert_called_once(), "msg"` builds a dead tuple, never
-    # surfaces "msg" — the check itself (assert_called_once) still enforces correctly.
-    mock_numpy.close.assert_called_once()
+    mock_numpy.close.assert_called_once_with()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_importer_cov_backends.py
+++ b/tests/core/test_importer_cov_backends.py
@@ -213,7 +213,7 @@ def test_numpy_backend_prepare_closes_and_rebuilds_on_format_change() -> None:
     imp._format = Format.from_overrides((8, 8, 4), "uint8")
     backend.prepare(imp)
 
-    close_spy.assert_called_once()
+    close_spy.assert_called_once_with()
     assert imp._numpy is not old_numpy
     assert imp._numpy.buffer.shape == (8, 8, 4)
 
@@ -343,7 +343,7 @@ def test_cupy_backend_wait_default_stream_uses_get_current_stream() -> None:
         waited = backend.wait(conn, 0)
 
     assert waited == 0.0
-    mock_cp.cuda.get_current_stream.assert_called_once()
+    mock_cp.cuda.get_current_stream.assert_called_once_with()
     # Pin the resolved stream's .ptr (0xAAAA), not just "called once" -- a bug
     # that threads the wrong pointer (e.g. 0, or self._stream instead of the
     # resolved current stream) would still satisfy a bare assert_called_once().

--- a/tests/core/test_importer_cov_lifecycle.py
+++ b/tests/core/test_importer_cov_lifecycle.py
@@ -303,4 +303,4 @@ def test_reinitialize_falls_back_to_partial_cleanup_on_failure(monkeypatch: pyte
 
     imp._reinitialize()  # must not raise
 
-    spy.assert_called_once()
+    spy.assert_called_once_with()

--- a/tests/cuda/test_cuda_graphs_cov.py
+++ b/tests/cuda/test_cuda_graphs_cov.py
@@ -18,6 +18,7 @@ No @pytest.mark.requires_cuda / requires_native marker needed.
 from __future__ import annotations
 
 from ctypes import POINTER, c_int, c_void_p, cast
+from unittest.mock import ANY
 
 from cuda_link.cuda_runtime_types import MemcpyKind
 from tests.fakes import make_bare_runtime_api
@@ -169,10 +170,10 @@ def test_graph_exec_memcpy_node_set_params_builds_params_and_forwards() -> None:
 
     api.graph_exec_memcpy_node_set_params(graph_exec, node, dst, src, 128, MemcpyKind.DEVICE_TO_DEVICE)
 
-    api.cudart.cudaGraphExecMemcpyNodeSetParams.assert_called_once()
-    call_args = api.cudart.cudaGraphExecMemcpyNodeSetParams.call_args[0]
-    assert call_args[0] is graph_exec
-    assert call_args[1] is node
+    # 3rd positional arg is byref(params) -- a freshly-built cudaMemcpy3DParms
+    # struct with no independently derivable literal to compare against, so
+    # it's pinned with ANY; graph_exec/node identity is still checked.
+    api.cudart.cudaGraphExecMemcpyNodeSetParams.assert_called_once_with(graph_exec, node, ANY)
 
 
 def test_graph_exec_memcpy_node_set_params_1d_converts_pointers_to_raw_ints() -> None:
@@ -248,5 +249,6 @@ def test_get_runtime_version_returns_int() -> None:
 
     result = api.get_runtime_version()
 
-    api.cudart.cudaRuntimeGetVersion.assert_called_once()
+    # byref(version) is a fresh out-param pointer -- pinned with ANY.
+    api.cudart.cudaRuntimeGetVersion.assert_called_once_with(ANY)
     assert result == 12080

--- a/tests/cuda/test_graph_coexistence_capture.py
+++ b/tests/cuda/test_graph_coexistence_capture.py
@@ -50,6 +50,14 @@ def test_concurrent_captures_mode_relaxed(cuda_runtime: object) -> None:
 
 
 @pytest.mark.requires_cuda
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "mode=0 may produce cudaErrorStreamCaptureInvalidated (901) on some "
+        "CUDA/driver combos -- documents the C2 regression. If this stops "
+        "xfailing, the driver changed behaviour and C2's fix may need re-evaluation."
+    ),
+)
 def test_mode0_invalidates_concurrent_capture(cuda_runtime: object) -> None:
     """Verify that mode=0 DOES cause the collision (documents the regression).
 
@@ -80,11 +88,11 @@ def test_mode0_invalidates_concurrent_capture(cuda_runtime: object) -> None:
     t2.join()
 
     # With mode=0 on some CUDA/driver combinations this will fail (error 901).
-    # We mark xfail so CI does not hard-fail if the driver happens to serialize
-    # captures, but we document the expected bad outcome.
-    if errors:
-        pytest.xfail(f"mode=0 produced errors as expected (C2 regression confirmed): {errors}")
-    else:
+    # The class-level xfail marker (strict=True) turns that failure into an
+    # expected-failure outcome instead of a hard CI failure. If the driver
+    # happens to serialize captures instead, skip rather than XPASS.
+    if not errors:
         pytest.skip(
             "mode=0 did not produce errors on this driver — driver may serialize captures; C2 fix still safe to land."
         )
+    raise AssertionError(f"mode=0 produced errors as expected (C2 regression confirmed): {errors}")

--- a/tests/cuda/test_nvml_observer_cov.py
+++ b/tests/cuda/test_nvml_observer_cov.py
@@ -230,11 +230,11 @@ def test_context_manager_calls_start_and_stop():
 
     with obs as ctx:
         assert ctx is obs
-        obs.start.assert_called_once()
+        obs.start.assert_called_once_with()
         obs.stop.assert_not_called()
 
-    obs.start.assert_called_once()
-    obs.stop.assert_called_once()
+    obs.start.assert_called_once_with()
+    obs.stop.assert_called_once_with()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cuda/test_wrapper_cov_dll_loading.py
+++ b/tests/cuda/test_wrapper_cov_dll_loading.py
@@ -82,7 +82,8 @@ def test_load_cuda_runtime_full_path_tier_oserror_falls_through_to_bare_name() -
 
     assert result is fake_dll
     assert mock_cdll.called
-    mock_log.assert_called_once()
+    # All 8 absolute paths fail; the bare-name tier's first candidate succeeds.
+    mock_log.assert_called_once_with(fake_dll, "cudart64_13.dll")
 
 
 def test_load_cuda_runtime_bare_name_tier_skips_failures_then_succeeds() -> None:
@@ -109,7 +110,7 @@ def test_load_cuda_runtime_bare_name_tier_skips_failures_then_succeeds() -> None
     # Both failing names were tried (except/continue branch) before the success.
     assert attempts[:2] == ["cudart64_13.dll", "cudart64_12.dll"]
     assert attempts[2] == "cudart64_11.dll"
-    mock_log.assert_called_once()
+    mock_log.assert_called_once_with(fake_dll, "cudart64_11.dll")
 
 
 def test_load_cuda_runtime_raises_with_winerror_126_hint() -> None:
@@ -295,7 +296,7 @@ def test_load_driver_api_cuinit_nonzero_returns_none() -> None:
         result = api._load_driver_api()
 
     assert result is None
-    fake_drv.cuInit.assert_called_once()
+    fake_drv.cuInit.assert_called_once_with(0)
 
 
 def test_load_driver_api_success_returns_drv() -> None:

--- a/tests/cuda/test_wrapper_cov_methods.py
+++ b/tests/cuda/test_wrapper_cov_methods.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from ctypes import POINTER, c_float, c_int, c_void_p, cast
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import pytest
 
@@ -100,7 +100,7 @@ def test_peek_last_error_returns_int() -> None:
     api.cudart.cudaPeekAtLastError.return_value = 17
 
     assert api.peek_last_error() == 17
-    api.cudart.cudaPeekAtLastError.assert_called_once()
+    api.cudart.cudaPeekAtLastError.assert_called_once_with()
 
 
 def test_check_sticky_error_noop_when_disabled() -> None:
@@ -249,6 +249,9 @@ def test_set_device_success_pushes_retained_ctx_stack() -> None:
     assert api._retained_ctx_stack == [2]
     assert isinstance(token, int)
     api._drv.cuDevicePrimaryCtxRetain.assert_called_once()
+    # 2nd arg is cu_dev, filled by cuDeviceGet -- mocked to succeed (return 0) without
+    # actually writing through byref, so it retains its zero-initialized default.
+    assert api._drv.cuDevicePrimaryCtxRetain.call_args[0][1].value == 0
 
 
 def test_set_device_failure_releases_retain_and_reraises() -> None:
@@ -265,6 +268,8 @@ def test_set_device_failure_releases_retain_and_reraises() -> None:
 
     assert api._retained_ctx_stack == []  # popped back out
     api._drv.cuDevicePrimaryCtxRelease.assert_called_once()
+    # Same cu_dev object retained above -- still zero-initialized (see retain test).
+    assert api._drv.cuDevicePrimaryCtxRelease.call_args[0][0].value == 0
 
 
 def test_set_device_fallback_when_no_driver_api() -> None:
@@ -386,7 +391,7 @@ def test_ipc_close_mem_handle_forwards_pointer() -> None:
 def test_synchronize_calls_device_synchronize() -> None:
     api = make_bare_runtime_api()
     api.synchronize()
-    api.cudart.cudaDeviceSynchronize.assert_called_once()
+    api.cudart.cudaDeviceSynchronize.assert_called_once_with()
 
 
 # ---------------------------------------------------------------------------
@@ -553,7 +558,7 @@ def test_get_device_returns_int() -> None:
 
     result = api.get_device()
 
-    api.cudart.cudaGetDevice.assert_called_once()
+    api.cudart.cudaGetDevice.assert_called_once_with(ANY)  # byref(device) -- opaque out-param
     assert result == 7
 
 
@@ -570,8 +575,10 @@ def test_create_stream_with_priority_queries_range_when_priority_none() -> None:
 
     api.create_stream_with_priority(priority=None)
 
-    api.cudart.cudaDeviceGetStreamPriorityRange.assert_called_once()
-    api.cudart.cudaStreamCreateWithPriority.assert_called_once()
+    api.cudart.cudaDeviceGetStreamPriorityRange.assert_called_once_with(ANY, ANY)  # opaque byref out-params
+    # priority is greatest.value -- the side_effect above never writes through byref,
+    # so greatest keeps its zero-initialized default; flags uses its NON_BLOCKING default.
+    api.cudart.cudaStreamCreateWithPriority.assert_called_once_with(ANY, StreamFlags.NON_BLOCKING, 0)
 
 
 def test_create_stream_with_priority_skips_range_query_when_explicit() -> None:
@@ -623,7 +630,7 @@ def test_memcpy_async_forwards_all_args() -> None:
 def test_mem_get_info_returns_tuple() -> None:
     api = make_bare_runtime_api()
     result = api.mem_get_info()
-    api.cudart.cudaMemGetInfo.assert_called_once()
+    api.cudart.cudaMemGetInfo.assert_called_once_with(ANY, ANY)  # opaque byref(free)/byref(total) out-params
     assert result == (0, 0)  # MagicMock never writes through byref; c_size_t() defaults to 0
 
 
@@ -680,7 +687,7 @@ def test_pointer_get_attributes_returns_struct() -> None:
 def test_device_can_access_peer_returns_bool() -> None:
     api = make_bare_runtime_api()
     result = api.device_can_access_peer(0, 1)
-    api.cudart.cudaDeviceCanAccessPeer.assert_called_once()
+    api.cudart.cudaDeviceCanAccessPeer.assert_called_once_with(ANY, 0, 1)  # byref(can_access) is opaque
     assert isinstance(result, bool)
 
 

--- a/tests/fakes/__init__.py
+++ b/tests/fakes/__init__.py
@@ -9,6 +9,9 @@ Also re-exports shared test doubles:
   - FakeTDHost, FakeTOPHandle, FakeCUDAMemoryRef, FakeCUDAMemoryShape (from td_exporter/_td_fakes.py)
   - FakeShmAdapter  (in-process fake for BarrierShmPort / HolderShmPort)
 
+Also provides the ``fake_exporter_open`` pytest fixture (patches ``Exporter.open`` for
+TDSender-engine tests) — see its docstring below.
+
 Import via ``from fakes import FakeShmAdapter, FakeTDHost, ...``
 (importlib-mode-safe — never ``from conftest import``).
 """
@@ -20,8 +23,11 @@ from ctypes import c_void_p
 from dataclasses import dataclass as _dataclass
 from unittest.mock import MagicMock
 
+import pytest
+
 # Re-export TD fake doubles (available via pythonpath = ["td_exporter"] in pyproject.toml)
 from _td_fakes import FakeCUDAMemoryRef, FakeCUDAMemoryShape, FakeTDHost, FakeTOPHandle  # noqa: F401
+from Exporter import Exporter
 
 from cuda_link.importer import IPCConnection
 from cuda_link.shm_protocol import SHMLayout
@@ -292,3 +298,27 @@ def make_bare_runtime_api(*, install_errcheck: bool = False, cudart: object | No
         api._setup_function_signatures()
         api._install_errcheck()
     return api
+
+
+# ---------------------------------------------------------------------------
+# fake_exporter_open — shared TDSender-engine fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_exporter_open(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch Exporter.open so every TDSender-internal open() returns a fake exporter.
+
+    Each ``tests/td/*.py`` module that uses this fixture defines its own local
+    ``_FakeExporter`` double (bodies are near-identical, but grow-safety tests need
+    an extra ``export_calls`` tracking list the others don't) — this fixture looks
+    that class up on the requesting test module via ``request.module._FakeExporter``
+    rather than hardcoding one, so the patching mechanics stay in one place while
+    each module keeps its own fake.
+    """
+    fake_exporter_cls = request.module._FakeExporter
+
+    def _patched_open(spec, *, policy=None, cuda=None, barrier=None):  # noqa: ANN001, ARG001
+        return fake_exporter_cls(spec)
+
+    monkeypatch.setattr(Exporter, "open", _patched_open)

--- a/tests/integration/test_cuda_ipc_exporter.py
+++ b/tests/integration/test_cuda_ipc_exporter.py
@@ -522,5 +522,6 @@ def test_float16_receiver_uses_gpu_path_when_cupy_available() -> None:
     assert result is True
     assert len(handle.copy_cuda_calls) == 1, "GPU path must call copy_cuda_memory once"
     assert len(handle.copy_numpy_calls) == 0, "GPU path must not call copy_numpy_array"
-    # ExternalStream context manager must be used
-    mock_cp.cuda.ExternalStream.assert_called_once()
+    # ExternalStream context manager must be used, wrapping the connection's
+    # stream handle (mock_stream.value = 0x1234, set in the helper above).
+    mock_cp.cuda.ExternalStream.assert_called_once_with(0x1234)

--- a/tests/integration/test_cuda_ipc_importer_cov.py
+++ b/tests/integration/test_cuda_ipc_importer_cov.py
@@ -226,7 +226,7 @@ def test_enter_calls_connect_when_not_connected():
     imp = CUDAIPCImporter(shm_name="x")
     with patch.object(imp, "connect") as mock_connect:
         result = imp.__enter__()
-    mock_connect.assert_called_once()
+    mock_connect.assert_called_once_with()
     assert result is imp
 
 
@@ -243,7 +243,7 @@ def test_exit_calls_cleanup():
     imp = CUDAIPCImporter(shm_name="x")
     with patch.object(imp, "cleanup") as mock_cleanup:
         imp.__exit__(None, None, None)
-    mock_cleanup.assert_called_once()
+    mock_cleanup.assert_called_once_with()
 
 
 def test_context_manager_full_roundtrip():

--- a/tests/support/test_doorbell.py
+++ b/tests/support/test_doorbell.py
@@ -11,7 +11,6 @@ Three groups:
 from __future__ import annotations
 
 import os
-import sys
 
 import pytest
 
@@ -36,7 +35,6 @@ def test_doorbell_event_name_format() -> None:
 
 def _make_importer(write_idx: int = 1, last_write_idx: int = 0) -> object:
     """Return a connected Importer via fakes.make_connected_importer()."""
-    sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
     from fakes import make_connected_importer  # type: ignore[import]
 
     return make_connected_importer(write_idx=write_idx, last_write_idx=last_write_idx)

--- a/tests/td/test_example_receiver_launcher.py
+++ b/tests/td/test_example_receiver_launcher.py
@@ -1,0 +1,60 @@
+"""
+Regression test: example_receiver_launcher._find_python_exe() / onStart() must not fall back
+to spawning a bare, unverified "python" when no interpreter can be resolved (#4 in the
+td_exporter audit).
+
+Mirrors test_example_sender_launcher.py -- see that file's docstring for the bug this guards
+against. The receiver launcher's final fallback now checks shutil.which("python") and returns
+None if it doesn't resolve, and onStart() prints a clear, actionable error and returns without
+spawning anything (and without touching the TD `project` global, which does not exist outside
+a TouchDesigner process).
+"""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _reset_module():
+    """(Re)import example_receiver_launcher fresh so module-level globals (_process,
+    _RECEIVER_PYTHON_EXE) don't bleed state between tests."""
+    import example_receiver_launcher as mod
+
+    importlib.reload(mod)
+    return mod
+
+
+def test_find_python_exe_returns_none_when_nothing_resolves(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_find_python_exe() must return None (not the bare string 'python') when no
+    interpreter can be resolved via env var, 'py -3', or PATH."""
+    mod = _reset_module()
+
+    monkeypatch.delenv("CUDALINK_RECEIVER_PYTHON_EXE", raising=False)
+    monkeypatch.setattr(mod.shutil, "which", lambda name: None)
+
+    result = mod._find_python_exe()
+    assert result is None, "must return None, not silently fall back to an unverified bare 'python'"
+
+
+def test_onstart_does_not_spawn_when_no_interpreter_resolved(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """onStart() must not call subprocess.Popen -- and must not touch the TD `project`
+    global -- when _RECEIVER_PYTHON_EXE is None; it should print a clear error and return."""
+    mod = _reset_module()
+
+    monkeypatch.setattr(mod, "_RECEIVER_PYTHON_EXE", None)
+    mock_popen = MagicMock()
+    monkeypatch.setattr(mod.subprocess, "Popen", mock_popen)
+
+    mod.onStart()  # must return before referencing `project.folder` (undefined outside TD)
+
+    mock_popen.assert_not_called()
+    assert mod._process is None
+
+    captured = capsys.readouterr()
+    assert "ERROR" in captured.out
+    assert "CUDALINK_RECEIVER_PYTHON_EXE" in captured.out

--- a/tests/td/test_example_sender_launcher.py
+++ b/tests/td/test_example_sender_launcher.py
@@ -3,25 +3,21 @@ Regression test: example_sender_launcher._find_python_exe() / onStart() must not
 to spawning a bare, unverified "python" when no interpreter can be resolved (#4 in the
 td_exporter audit).
 
-Background: the sibling receiver launcher (example_receiver_launcher.py) blindly returns the
-literal string "python" as its final fallback -- if nothing is actually on PATH, Popen raises
-deep inside the subprocess with an opaque error. The sender launcher was hardened instead: its
-final fallback checks shutil.which("python") and returns None if it doesn't resolve, and
-onStart() prints a clear, actionable error and returns without spawning anything (and without
-touching the TD `project` global, which does not exist outside a TouchDesigner process).
+Fix: the final fallback checks shutil.which("python") and returns None if it doesn't resolve,
+and onStart() prints a clear, actionable error and returns without spawning anything (and
+without touching the TD `project` global, which does not exist outside a TouchDesigner
+process). The sibling receiver launcher (example_receiver_launcher.py) originally had the bug
+this test guards against -- it blindly returned the literal string "python" as its final
+fallback, so a missing PATH entry would make Popen raise deep inside the subprocess with an
+opaque error. It was hardened to match this module; see test_example_receiver_launcher.py.
 """
 
 from __future__ import annotations
 
 import importlib
-import sys
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
 
 
 def _reset_module():

--- a/tests/td/test_report_window.py
+++ b/tests/td/test_report_window.py
@@ -8,13 +8,7 @@ and import directly from the canonical src/cuda_link/_profile module.
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT / "src"))
-
-from cuda_link._profile import ReportWindow  # noqa: E402
+from cuda_link._profile import ReportWindow
 
 # ---------------------------------------------------------------------------
 # add_sample / avg_and_reset basics

--- a/tests/td/test_td_callbacks_dispatch.py
+++ b/tests/td/test_td_callbacks_dispatch.py
@@ -26,18 +26,11 @@ handler must fire per parameter name, and unrecognized names must dispatch to no
 
 from __future__ import annotations
 
-import sys
 import types
-from pathlib import Path
 
+import parexecute_callbacks
 import pytest
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
-sys.path.insert(0, str(_REPO_ROOT / "src"))
-
-import parexecute_callbacks  # noqa: E402
-import script_top_callbacks  # noqa: E402
+import script_top_callbacks
 
 # ---------------------------------------------------------------------------
 # script_top_callbacks.onCook

--- a/tests/td/test_td_status_emission.py
+++ b/tests/td/test_td_status_emission.py
@@ -22,22 +22,15 @@ built _FakeExporter double stands in for Exporter.open()).
 
 from __future__ import annotations
 
-import sys
 import types
 import uuid
-from pathlib import Path
 
 import pytest
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
-sys.path.insert(0, str(_REPO_ROOT / "src"))
-
-from Exporter import Exporter, FrameOutcome  # noqa: E402
-from fakes import FakeTDHost, FakeTOPHandle  # noqa: E402
-from SHMProtocol import DtypeCodec  # noqa: E402
-from TDConfig import TDSenderConfig  # noqa: E402
-from TDSender import TDSenderEngine  # noqa: E402
+from Exporter import Exporter, FrameOutcome
+from fakes import FakeTDHost, FakeTOPHandle, fake_exporter_open  # noqa: F401
+from SHMProtocol import DtypeCodec
+from TDConfig import TDSenderConfig
+from TDSender import TDSenderEngine
 
 
 class _FakeExporter:
@@ -63,14 +56,6 @@ class _FakeExporter:
 
     def close(self) -> None:
         pass
-
-
-@pytest.fixture
-def fake_exporter_open(monkeypatch: pytest.MonkeyPatch):
-    def _patched_open(spec, *, policy=None, cuda=None, barrier=None):  # noqa: ANN001, ARG001
-        return _FakeExporter(spec)
-
-    monkeypatch.setattr(Exporter, "open", _patched_open)
 
 
 def _make_engine(shm_name: str, host: FakeTDHost) -> TDSenderEngine:

--- a/tests/td/test_tdhost_default_color_cache.py
+++ b/tests/td/test_tdhost_default_color_cache.py
@@ -12,15 +12,7 @@ a settable .color field.  No TD runtime required.
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT))
-sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
-sys.path.insert(0, str(_REPO_ROOT / "src"))
-
-from TDHost import RealTDHost  # noqa: E402
+from TDHost import RealTDHost
 
 _WARNING_COLOR = (0.9137, 1.0, 0.0)
 _ERROR_COLOR = (0.7, 0.0, 0.0)

--- a/tests/td/test_tdhost_status_par.py
+++ b/tests/td/test_tdhost_status_par.py
@@ -9,15 +9,7 @@ and clear_status each also push a value to the Status par.
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT))
-sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
-sys.path.insert(0, str(_REPO_ROOT / "src"))
-
-from TDHost import RealTDHost  # noqa: E402
+from TDHost import RealTDHost
 
 # ---------------------------------------------------------------------------
 # Fake TD objects

--- a/tests/td/test_tdhost_warning_emitter.py
+++ b/tests/td/test_tdhost_warning_emitter.py
@@ -9,15 +9,7 @@ every frame) from force-cooking the emitter repeatedly.
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT))
-sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
-sys.path.insert(0, str(_REPO_ROOT / "src"))
-
-from TDHost import RealTDHost  # noqa: E402
+from TDHost import RealTDHost
 
 _WARNING_COLOR = (0.9137, 1.0, 0.0)
 _ERROR_COLOR = (0.7, 0.0, 0.0)

--- a/tests/td/test_tdreceiver_dtype_refresh.py
+++ b/tests/td/test_tdreceiver_dtype_refresh.py
@@ -14,17 +14,10 @@ in-place refresh seam independently of the sender bug.
 from __future__ import annotations
 
 import contextlib
-import sys
 import uuid
 from multiprocessing.shared_memory import SharedMemory
-from pathlib import Path
 
 import pytest
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT))
-sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
-sys.path.insert(0, str(_REPO_ROOT / "src"))
 
 
 def _make_receiver(shm_name: str):

--- a/tests/td/test_tdreceiver_has_new_frame.py
+++ b/tests/td/test_tdreceiver_has_new_frame.py
@@ -23,18 +23,10 @@ from __future__ import annotations
 
 import contextlib
 import struct
-import sys
 import uuid
 from multiprocessing.shared_memory import SharedMemory
-from pathlib import Path
 
 import pytest
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT))
-sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
-sys.path.insert(0, str(_REPO_ROOT / "src"))
-
 
 # ---------------------------------------------------------------------------
 # Shared harness (mirrors test_tdreceiver_dtype_refresh)

--- a/tests/td/test_tdreceiver_retry_backoff.py
+++ b/tests/td/test_tdreceiver_retry_backoff.py
@@ -22,18 +22,10 @@ retry_interval_frames wait -- avoiding an actual multi-hundred-frame simulation 
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
 import pytest
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
-sys.path.insert(0, str(_REPO_ROOT / "src"))
-
-from fakes import FakeTDHost  # noqa: E402
-from TDConfig import TDReceiverConfig  # noqa: E402
-from TDReceiver import TDReceiverEngine  # noqa: E402
+from fakes import FakeTDHost
+from TDConfig import TDReceiverConfig
+from TDReceiver import TDReceiverEngine
 
 
 def _make_engine(log_calls: list[str]) -> TDReceiverEngine:

--- a/tests/td/test_tdreceiver_shm_leak.py
+++ b/tests/td/test_tdreceiver_shm_leak.py
@@ -18,17 +18,10 @@ Fix: track `shm_handle` independently of `connection_committed` and close it in 
 from __future__ import annotations
 
 import contextlib
-import sys
 import uuid
 from multiprocessing.shared_memory import SharedMemory
-from pathlib import Path
 
 import pytest
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT))
-sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
-sys.path.insert(0, str(_REPO_ROOT / "src"))
 
 
 def _make_receiver(shm_name: str):

--- a/tests/td/test_tdsender_dtype_runtime_change.py
+++ b/tests/td/test_tdsender_dtype_runtime_change.py
@@ -22,17 +22,10 @@ All helpers tested here are pure (no CUDA, no SHM) — can run without hardware.
 
 from __future__ import annotations
 
-import sys
 import types
-from pathlib import Path
 
 import pytest
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
-sys.path.insert(0, str(_REPO_ROOT / "src"))
-
-from TDSender import _cm_dtype_to_str, _guess_dtype_from_buffer_size, _resolve_frame_dtype  # noqa: E402
+from TDSender import _cm_dtype_to_str, _guess_dtype_from_buffer_size, _resolve_frame_dtype
 
 # ---------------------------------------------------------------------------
 # _cm_dtype_to_str — unchanged but exercised for completeness

--- a/tests/td/test_tdsender_export_sync_default.py
+++ b/tests/td/test_tdsender_export_sync_default.py
@@ -17,15 +17,6 @@ IPC ring buffer, and a loaded consumer; that finding is documented in the plan.
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT))
-sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
-sys.path.insert(0, str(_REPO_ROOT / "src"))
-
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/td/test_tdsender_format_rejection.py
+++ b/tests/td/test_tdsender_format_rejection.py
@@ -14,17 +14,10 @@ Rejected formats (5 hard exceptions + 1 silent corruption):
 
 from __future__ import annotations
 
-import sys
 import types
 import uuid
-from pathlib import Path
 
 import pytest
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT))
-sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
-sys.path.insert(0, str(_REPO_ROOT / "src"))
 
 
 def _make_engine(shm_name: str):

--- a/tests/td/test_tdsender_format_warning.py
+++ b/tests/td/test_tdsender_format_warning.py
@@ -13,17 +13,10 @@ Source of truth: verification/results/cuda_memory_probe_20260510_090919.json
 
 from __future__ import annotations
 
-import sys
 import types
 import uuid
-from pathlib import Path
 
 import pytest
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT))
-sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
-sys.path.insert(0, str(_REPO_ROOT / "src"))
 
 
 def _make_engine_with_spy(shm_name: str):

--- a/tests/td/test_tdsender_grow_safety.py
+++ b/tests/td/test_tdsender_grow_safety.py
@@ -27,22 +27,14 @@ covered by tests/core/test_exporter_python.py).
 
 from __future__ import annotations
 
-import sys
 import types
 import uuid
-from pathlib import Path
 
-import pytest
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
-sys.path.insert(0, str(_REPO_ROOT / "src"))
-
-from Exporter import Exporter, FrameOutcome  # noqa: E402
-from fakes import FakeTDHost, FakeTOPHandle  # noqa: E402
-from SHMProtocol import DtypeCodec  # noqa: E402
-from TDConfig import TDSenderConfig  # noqa: E402
-from TDSender import TDSenderEngine  # noqa: E402
+from Exporter import FrameOutcome
+from fakes import FakeTDHost, FakeTOPHandle, fake_exporter_open  # noqa: F401
+from SHMProtocol import DtypeCodec
+from TDConfig import TDSenderConfig
+from TDSender import TDSenderEngine
 
 
 class _FakeExporter:
@@ -75,16 +67,6 @@ class _FakeExporter:
 
     def close(self) -> None:
         pass
-
-
-@pytest.fixture
-def fake_exporter_open(monkeypatch: pytest.MonkeyPatch):
-    """Patch Exporter.open so every TDSender-internal open() returns a _FakeExporter."""
-
-    def _patched_open(spec, *, policy=None, cuda=None, barrier=None):  # noqa: ANN001, ARG001
-        return _FakeExporter(spec)
-
-    monkeypatch.setattr(Exporter, "open", _patched_open)
 
 
 def _make_engine(shm_name: str, host: FakeTDHost) -> TDSenderEngine:

--- a/tests/td/test_tdsender_h2_channel_inference.py
+++ b/tests/td/test_tdsender_h2_channel_inference.py
@@ -15,22 +15,14 @@ See test_tdsender_grow_safety.py for the shared GPU-free harness rationale.
 
 from __future__ import annotations
 
-import sys
 import types
 import uuid
-from pathlib import Path
 
-import pytest
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
-sys.path.insert(0, str(_REPO_ROOT / "src"))
-
-from Exporter import Exporter, FrameOutcome  # noqa: E402
-from fakes import FakeTDHost, FakeTOPHandle  # noqa: E402
-from SHMProtocol import DtypeCodec  # noqa: E402
-from TDConfig import TDSenderConfig  # noqa: E402
-from TDSender import TDSenderEngine  # noqa: E402
+from Exporter import FrameOutcome
+from fakes import FakeTDHost, FakeTOPHandle, fake_exporter_open  # noqa: F401
+from SHMProtocol import DtypeCodec
+from TDConfig import TDSenderConfig
+from TDSender import TDSenderEngine
 
 
 class _FakeExporter:
@@ -56,14 +48,6 @@ class _FakeExporter:
 
     def close(self) -> None:
         pass
-
-
-@pytest.fixture
-def fake_exporter_open(monkeypatch: pytest.MonkeyPatch):
-    def _patched_open(spec, *, policy=None, cuda=None, barrier=None):  # noqa: ANN001, ARG001
-        return _FakeExporter(spec)
-
-    monkeypatch.setattr(Exporter, "open", _patched_open)
 
 
 def _make_engine(shm_name: str, host: FakeTDHost, log_calls: list[str] | None = None) -> TDSenderEngine:

--- a/tests/td/test_tdsender_pixelformat_override.py
+++ b/tests/td/test_tdsender_pixelformat_override.py
@@ -17,22 +17,14 @@ stream sentinel has no `.value` attribute that TDSender's ipc_stream handling ne
 
 from __future__ import annotations
 
-import sys
 import types
 import uuid
-from pathlib import Path
 
-import pytest
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
-sys.path.insert(0, str(_REPO_ROOT / "src"))
-
-from Exporter import Exporter, FrameOutcome  # noqa: E402
-from fakes import FakeTDHost, FakeTOPHandle  # noqa: E402
-from SHMProtocol import DtypeCodec  # noqa: E402
-from TDConfig import TDSenderConfig  # noqa: E402
-from TDSender import TDSenderEngine  # noqa: E402
+from Exporter import FrameOutcome
+from fakes import FakeTDHost, FakeTOPHandle, fake_exporter_open  # noqa: F401
+from SHMProtocol import DtypeCodec
+from TDConfig import TDSenderConfig
+from TDSender import TDSenderEngine
 
 
 class _FakeExporter:
@@ -58,14 +50,6 @@ class _FakeExporter:
 
     def close(self) -> None:
         pass
-
-
-@pytest.fixture
-def fake_exporter_open(monkeypatch: pytest.MonkeyPatch):
-    def _patched_open(spec, *, policy=None, cuda=None, barrier=None):  # noqa: ANN001, ARG001
-        return _FakeExporter(spec)
-
-    monkeypatch.setattr(Exporter, "open", _patched_open)
 
 
 def _make_engine(shm_name: str, host: FakeTDHost, log_calls: list[str] | None = None) -> TDSenderEngine:

--- a/tests/td/test_tdsender_report.py
+++ b/tests/td/test_tdsender_report.py
@@ -12,16 +12,8 @@ and call _maybe_report_stats directly so no cuda_memory() / CUDA path is exercis
 
 from __future__ import annotations
 
-import sys
 import types
 import uuid
-from pathlib import Path
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT))
-sys.path.insert(0, str(_REPO_ROOT / "td_exporter"))
-sys.path.insert(0, str(_REPO_ROOT / "src"))
-
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Summary

Promotes everything currently on `development` to `master`:

- **Harden-test-suite campaign** (Phase E + F): root-causes and fixes the order-dependent
  `activation_barrier` flake via a per-test SHM isolation fixture; closes three previously
  unrecorded audit gaps -- a test-value triage table, a Phase 0.5 prune (redundant
  `sys.path.insert` calls, unpinned mock assertions, a duplicated fixture, a non-strict
  `xfail`, an unused dependency), a McCabe complexity ceiling (`C901`, ratcheted downward-only),
  and an honest coverage denominator with `fail_under` ratcheted 76 -> 85.
- **Dependency fix**: corrects a `crap4py` pin introduced by the campaign that broke the
  Python 3.9 CI gate (the version didn't exist on PyPI, and the only real release requires
  Python >=3.10); the quality tooling now lives in its own `[quality]` extra, kept out of
  `[dev]` so it can never break the 3.9 install again.
- **`example_receiver_launcher.py` hardening**: ports the sender launcher's `shutil.which`
  python-exe fallback guard, closing a known 0%-covered gap.
- **Docs fix**: corrects `docs/ARCHITECTURE.md` / `docs/TOX_BUILD_GUIDE.md` to describe library
  mode's actual activation path (TD Preferences module path, not just `CUDALINK_LIB_PATH`).
- **`claude-code-action` bump**: 1.0.187 -> 1.0.193 (dependabot).
- **Hook guard + changelog cleanup**: the original scope of this PR before `development` moved
  forward underneath it -- scopes `cc-block-dangerous-git.sh`'s pattern checks to a single
  shell invocation so a flag on one command in a `;`-chained line can't exempt a different
  command, plus a changelog heading/table normalization pass.

## Test plan

- [x] All CI workflows (Tests, Branch Protection incl. the Python 3.9 gate, Type Check,
      Native Build, Documentation Validation, Claude Code Review) green on `development` at
      the commit this PR promotes
- [x] 20x randomized full-suite runs + 20x targeted barrier-file reproduction, both green
      with a stable skip count (part of the harden-test-suite campaign's own verification)
- [x] `pip install -e ".[quality]"` resolves on Python 3.9 (crap4py simply skipped) and on
      3.10+ (crap4py installs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)